### PR TITLE
chore(deps): migrate to shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,7 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "config:recommended",
-      ":dependencyDashboard",
-      ":disableRateLimiting",
-      ":timezone(America/Los_Angeles)",
-      ":semanticCommits"
-    ],
-    "dependencyDashboardTitle": "Renovate Dashboard 🤖",
-    "suppressNotifications": [
-      "prEditedNotification",
-      "prIgnoreNotification"
-    ],
-    "postUpdateOptions": [
-      "gomodTidy"
-    ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jacaudi/renovate-config:base",
+    "github>jacaudi/renovate-config:go"
+  ]
 }


### PR DESCRIPTION
## Summary
- Use shared presets from `jacaudi/renovate-config`

## Presets Used
- `base` - Common settings, GitHub Actions grouping
- `go` - Go mod tidy

Generated with [Claude Code](https://claude.com/claude-code)