### PR TITLE
feat: poll radar image and attach to VCP-change notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@
 - Power Source
 - Generator State
 
-When a VCP change is detected, the latest radar image (downloaded at the same poll
-that detected the change) is attached to the Pushover notification.
+Each poll downloads the latest radar image and keeps a sliding window of the last
+hour of images per station (configurable via `RADAR_IMAGE_RETENTION`). When a VCP
+change is detected, the freshly downloaded image is attached to the Pushover
+notification. All radar image requests use the same User-Agent as the NWS API
+calls.
 
 ## How To Use
 
@@ -37,7 +40,8 @@ that detected the change) is attached to the Pushover notification.
     - `ALERT_POWER_SOURCE` — Enable Alerts on changes to radar power source (default: `false`)
     - `ALERT_GEN_STATE` — Enable Alerts on changes to generator state (default: `false`)
     - `RADAR_IMAGE_ENABLED` — Poll the radar image every check and attach it to VCP-change notifications (default: `true`)
-    - `RADAR_IMAGE_URL_TEMPLATE` — Override the radar image URL. Use `{station}` as the station-ID placeholder (default: NWS Ridge GIF)
+    - `RADAR_IMAGE_URL_TEMPLATE` — Override the radar image URL. Use `{station}` as the station-ID placeholder (default: NWS Ridge GIF — the highest-resolution per-station single image NWS publishes via static URL)
+    - `RADAR_IMAGE_RETENTION` — Sliding window of polled images kept per station, parsed as a Go duration like `1h` or `30m` (default: `1h`)
  4. Enjoy!
 
 ### Standalone Container Method

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 - Power Source
 - Generator State
 
+When a VCP change is detected, the latest radar image (downloaded at the same poll
+that detected the change) is attached to the Pushover notification.
+
 ## How To Use
 
 ### Requirements
@@ -33,6 +36,8 @@
     - `ALERT_OPERABILITY` — Enable Alerts on changes to radar operability status (default: `false`)
     - `ALERT_POWER_SOURCE` — Enable Alerts on changes to radar power source (default: `false`)
     - `ALERT_GEN_STATE` — Enable Alerts on changes to generator state (default: `false`)
+    - `RADAR_IMAGE_ENABLED` — Poll the radar image every check and attach it to VCP-change notifications (default: `true`)
+    - `RADAR_IMAGE_URL_TEMPLATE` — Override the radar image URL. Use `{station}` as the station-ID placeholder (default: NWS Ridge GIF)
  4. Enjoy!
 
 ### Standalone Container Method

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,13 +17,15 @@ import (
 
 // Config holds all configuration for the DRAS application.
 type Config struct {
-	StationInput     string
-	PushoverAPIToken string
-	PushoverUserKey  string
-	DryRun           bool
-	CheckInterval    time.Duration
-	LogLevel         string
-	AlertConfig      radar.AlertConfig
+	StationInput      string
+	PushoverAPIToken  string
+	PushoverUserKey   string
+	DryRun            bool
+	CheckInterval     time.Duration
+	LogLevel          string
+	AlertConfig       radar.AlertConfig
+	RadarImageEnabled bool
+	RadarImageURLTmpl string
 }
 
 // Load loads configuration from environment variables with proper error handling.
@@ -84,6 +86,13 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	cfg.RadarImageEnabled, err = parseBoolEnv("RADAR_IMAGE_ENABLED", "true")
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.RadarImageURLTmpl = os.Getenv("RADAR_IMAGE_URL_TEMPLATE")
 
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,15 +17,16 @@ import (
 
 // Config holds all configuration for the DRAS application.
 type Config struct {
-	StationInput      string
-	PushoverAPIToken  string
-	PushoverUserKey   string
-	DryRun            bool
-	CheckInterval     time.Duration
-	LogLevel          string
-	AlertConfig       radar.AlertConfig
-	RadarImageEnabled bool
-	RadarImageURLTmpl string
+	StationInput        string
+	PushoverAPIToken    string
+	PushoverUserKey     string
+	DryRun              bool
+	CheckInterval       time.Duration
+	LogLevel            string
+	AlertConfig         radar.AlertConfig
+	RadarImageEnabled   bool
+	RadarImageURLTmpl   string
+	RadarImageRetention time.Duration
 }
 
 // Load loads configuration from environment variables with proper error handling.
@@ -94,6 +95,16 @@ func Load() (*Config, error) {
 
 	cfg.RadarImageURLTmpl = os.Getenv("RADAR_IMAGE_URL_TEMPLATE")
 
+	retentionStr := os.Getenv("RADAR_IMAGE_RETENTION")
+	if retentionStr == "" {
+		cfg.RadarImageRetention = time.Hour
+	} else {
+		cfg.RadarImageRetention, err = time.ParseDuration(retentionStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid RADAR_IMAGE_RETENTION value '%s': %w", retentionStr, err)
+		}
+	}
+
 	return cfg, nil
 }
 
@@ -132,6 +143,10 @@ func (c *Config) Validate() error {
 		if err := validateLogLevel(c.LogLevel); err != nil {
 			errors = append(errors, fmt.Sprintf("LOG_LEVEL validation failed: %v", err))
 		}
+	}
+
+	if c.RadarImageEnabled && c.RadarImageRetention <= 0 {
+		errors = append(errors, "RADAR_IMAGE_RETENTION must be positive (e.g. 1h, 30m)")
 	}
 
 	if len(errors) > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,9 @@ func TestLoad(t *testing.T) {
 		"ALERT_OPERABILITY",
 		"ALERT_POWER_SOURCE",
 		"ALERT_GEN_STATE",
+		"RADAR_IMAGE_ENABLED",
+		"RADAR_IMAGE_URL_TEMPLATE",
+		"RADAR_IMAGE_RETENTION",
 	}
 
 	clearEnv := func(t *testing.T) {
@@ -47,6 +50,58 @@ func TestLoad(t *testing.T) {
 		}
 		if cfg.AlertConfig.Status {
 			t.Errorf("Expected Status alerts to be false by default")
+		}
+		if !cfg.RadarImageEnabled {
+			t.Errorf("Expected RadarImageEnabled to be true by default")
+		}
+		if cfg.RadarImageURLTmpl != "" {
+			t.Errorf("Expected RadarImageURLTmpl to default to empty (template applied at New), got %q", cfg.RadarImageURLTmpl)
+		}
+		if cfg.RadarImageRetention != time.Hour {
+			t.Errorf("Expected RadarImageRetention to default to 1h, got %v", cfg.RadarImageRetention)
+		}
+	})
+
+	t.Run("loads custom radar image configuration", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("DRYRUN", "true")
+		t.Setenv("RADAR_IMAGE_ENABLED", "false")
+		t.Setenv("RADAR_IMAGE_URL_TEMPLATE", "https://example.com/{station}.png")
+		t.Setenv("RADAR_IMAGE_RETENTION", "30m")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+
+		if cfg.RadarImageEnabled {
+			t.Errorf("Expected RadarImageEnabled=false")
+		}
+		if cfg.RadarImageURLTmpl != "https://example.com/{station}.png" {
+			t.Errorf("Expected custom URL template, got %q", cfg.RadarImageURLTmpl)
+		}
+		if cfg.RadarImageRetention != 30*time.Minute {
+			t.Errorf("Expected RadarImageRetention=30m, got %v", cfg.RadarImageRetention)
+		}
+	})
+
+	t.Run("handles invalid RADAR_IMAGE_RETENTION value", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("RADAR_IMAGE_RETENTION", "not-a-duration")
+
+		_, err := Load()
+		if err == nil {
+			t.Error("Expected error for invalid RADAR_IMAGE_RETENTION value")
+		}
+	})
+
+	t.Run("handles invalid RADAR_IMAGE_ENABLED value", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("RADAR_IMAGE_ENABLED", "maybe")
+
+		_, err := Load()
+		if err == nil {
+			t.Error("Expected error for invalid RADAR_IMAGE_ENABLED value")
 		}
 	})
 
@@ -134,6 +189,34 @@ func TestConfig_Validate(t *testing.T) {
 		}
 		if err := cfg.Validate(); err == nil {
 			t.Error("Validation should fail when missing required fields")
+		}
+	})
+
+	t.Run("fails when image enabled with non-positive retention", func(t *testing.T) {
+		cfg := &Config{
+			DryRun:              true,
+			CheckInterval:       5 * time.Minute,
+			RadarImageEnabled:   true,
+			RadarImageRetention: 0,
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("Validation should fail when retention is 0 with image polling enabled")
+		}
+		if !strings.Contains(err.Error(), "RADAR_IMAGE_RETENTION") {
+			t.Errorf("error %q should mention RADAR_IMAGE_RETENTION", err)
+		}
+	})
+
+	t.Run("passes when image disabled regardless of retention", func(t *testing.T) {
+		cfg := &Config{
+			DryRun:              true,
+			CheckInterval:       5 * time.Minute,
+			RadarImageEnabled:   false,
+			RadarImageRetention: 0,
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validation should pass when image polling is disabled, got %v", err)
 		}
 	})
 }

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -1,0 +1,142 @@
+// Package image fetches and caches radar images so they can be attached to
+// notifications when a change in radar state is detected.
+package image
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jacaudi/dras/internal/logger"
+)
+
+// DefaultURLTemplate is the default NWS radar image URL pattern. The
+// "{station}" placeholder is replaced with the station ID at fetch time.
+const DefaultURLTemplate = "https://radar.weather.gov/ridge/standard/{station}_0.gif"
+
+// stationPlaceholder is the token replaced with the station ID inside a URL
+// template.
+const stationPlaceholder = "{station}"
+
+// defaultTimeout is the HTTP timeout used when callers do not supply a custom
+// client.
+const defaultTimeout = 30 * time.Second
+
+// Image is a downloaded radar image plus the metadata needed to attach it to a
+// notification.
+type Image struct {
+	StationID   string
+	Data        []byte
+	ContentType string
+	Filename    string
+	FetchedAt   time.Time
+}
+
+// Service downloads radar images and caches the most recent image for each
+// station so it can be attached when a change notification fires.
+type Service struct {
+	httpClient  *http.Client
+	urlTemplate string
+
+	mu    sync.RWMutex
+	cache map[string]*Image
+}
+
+// New creates a new image service. If urlTemplate is empty the default NWS
+// template is used.
+func New(urlTemplate string) *Service {
+	if urlTemplate == "" {
+		urlTemplate = DefaultURLTemplate
+	}
+	return &Service{
+		httpClient:  &http.Client{Timeout: defaultTimeout},
+		urlTemplate: urlTemplate,
+		cache:       make(map[string]*Image),
+	}
+}
+
+// URLFor returns the radar image URL for the given station based on the
+// configured template.
+func (s *Service) URLFor(stationID string) string {
+	return strings.ReplaceAll(s.urlTemplate, stationPlaceholder, stationID)
+}
+
+// Fetch downloads the radar image for the station and stores it in the cache.
+// The latest image is also returned so callers can use it immediately.
+func (s *Service) Fetch(stationID string) (*Image, error) {
+	if stationID == "" {
+		return nil, errors.New("stationID cannot be empty")
+	}
+
+	url := s.URLFor(stationID)
+	logger.WithFields(map[string]string{
+		"station": stationID,
+		"url":     url,
+	}).Debug("Fetching radar image")
+
+	resp, err := s.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching radar image for %s: %w", stationID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d fetching radar image for %s", resp.StatusCode, stationID)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading radar image for %s: %w", stationID, err)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = http.DetectContentType(data)
+	}
+
+	img := &Image{
+		StationID:   stationID,
+		Data:        data,
+		ContentType: contentType,
+		Filename:    filenameFor(stationID, contentType),
+		FetchedAt:   time.Now(),
+	}
+
+	s.mu.Lock()
+	s.cache[stationID] = img
+	s.mu.Unlock()
+
+	logger.WithFields(map[string]string{
+		"station":      stationID,
+		"bytes":        fmt.Sprintf("%d", len(data)),
+		"content_type": contentType,
+	}).Debug("Stored radar image")
+
+	return img, nil
+}
+
+// Get returns the most recently cached image for the station, if any.
+func (s *Service) Get(stationID string) (*Image, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	img, ok := s.cache[stationID]
+	return img, ok
+}
+
+// filenameFor builds a sensible attachment filename based on the content type.
+func filenameFor(stationID, contentType string) string {
+	ext := "gif"
+	switch {
+	case strings.Contains(contentType, "png"):
+		ext = "png"
+	case strings.Contains(contentType, "jpeg"), strings.Contains(contentType, "jpg"):
+		ext = "jpg"
+	case strings.Contains(contentType, "gif"):
+		ext = "gif"
+	}
+	return fmt.Sprintf("%s.%s", stationID, ext)
+}

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -16,7 +17,12 @@ import (
 
 // DefaultURLTemplate is the default NWS radar image URL pattern. The
 // "{station}" placeholder is replaced with the station ID at fetch time.
+// This is the highest-resolution single-image per-station product NWS
+// publishes via a static URL (600x550 GIF).
 const DefaultURLTemplate = "https://radar.weather.gov/ridge/standard/{station}_0.gif"
+
+// DefaultRetention is the default sliding-window length for cached images.
+const DefaultRetention = time.Hour
 
 // stationPlaceholder is the token replaced with the station ID inside a URL
 // template.
@@ -36,27 +42,64 @@ type Image struct {
 	FetchedAt   time.Time
 }
 
-// Service downloads radar images and caches the most recent image for each
-// station so it can be attached when a change notification fires.
+// Config configures an image Service.
+type Config struct {
+	// URLTemplate is the radar image URL with "{station}" as the station-ID
+	// placeholder. Empty defaults to DefaultURLTemplate.
+	URLTemplate string
+	// Retention controls how long fetched images are kept in the per-station
+	// history. Zero or negative defaults to DefaultRetention.
+	Retention time.Duration
+	// UserAgent is sent on every image request. Empty means no override.
+	UserAgent string
+	// HTTPClient is the client used for fetching images. nil installs a
+	// client with a sensible timeout.
+	HTTPClient *http.Client
+}
+
+// Service downloads radar images and caches the most recent images for each
+// station so they can be attached when a change notification fires. The cache
+// is a sliding window keyed by FetchedAt.
 type Service struct {
 	httpClient  *http.Client
 	urlTemplate string
+	userAgent   string
+	retention   time.Duration
 
-	mu    sync.RWMutex
-	cache map[string]*Image
+	mu      sync.RWMutex
+	history map[string][]*Image
 }
 
-// New creates a new image service. If urlTemplate is empty the default NWS
-// template is used.
-func New(urlTemplate string) *Service {
-	if urlTemplate == "" {
-		urlTemplate = DefaultURLTemplate
+// New creates a new image service from the supplied config. Empty / zero
+// fields fall back to sensible defaults.
+func New(cfg Config) *Service {
+	tmpl := cfg.URLTemplate
+	if tmpl == "" {
+		tmpl = DefaultURLTemplate
 	}
+
+	retention := cfg.Retention
+	if retention <= 0 {
+		retention = DefaultRetention
+	}
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultTimeout}
+	}
+
 	return &Service{
-		httpClient:  &http.Client{Timeout: defaultTimeout},
-		urlTemplate: urlTemplate,
-		cache:       make(map[string]*Image),
+		httpClient:  client,
+		urlTemplate: tmpl,
+		userAgent:   cfg.UserAgent,
+		retention:   retention,
+		history:     make(map[string][]*Image),
 	}
+}
+
+// Retention returns the configured retention window.
+func (s *Service) Retention() time.Duration {
+	return s.retention
 }
 
 // URLFor returns the radar image URL for the given station based on the
@@ -65,8 +108,9 @@ func (s *Service) URLFor(stationID string) string {
 	return strings.ReplaceAll(s.urlTemplate, stationPlaceholder, stationID)
 }
 
-// Fetch downloads the radar image for the station and stores it in the cache.
-// The latest image is also returned so callers can use it immediately.
+// Fetch downloads the radar image for the station, appends it to the per
+// -station history, prunes images outside the retention window, and returns
+// the freshly downloaded image so callers can use it immediately.
 func (s *Service) Fetch(stationID string) (*Image, error) {
 	if stationID == "" {
 		return nil, errors.New("stationID cannot be empty")
@@ -78,7 +122,15 @@ func (s *Service) Fetch(stationID string) (*Image, error) {
 		"url":     url,
 	}).Debug("Fetching radar image")
 
-	resp, err := s.httpClient.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error building radar image request for %s: %w", stationID, err)
+	}
+	if s.userAgent != "" {
+		req.Header.Set("User-Agent", s.userAgent)
+	}
+
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching radar image for %s: %w", stationID, err)
 	}
@@ -98,37 +150,83 @@ func (s *Service) Fetch(stationID string) (*Image, error) {
 		contentType = http.DetectContentType(data)
 	}
 
+	now := time.Now()
 	img := &Image{
 		StationID:   stationID,
 		Data:        data,
 		ContentType: contentType,
-		Filename:    filenameFor(stationID, contentType),
-		FetchedAt:   time.Now(),
+		Filename:    filenameFor(stationID, contentType, now),
+		FetchedAt:   now,
 	}
 
 	s.mu.Lock()
-	s.cache[stationID] = img
+	s.history[stationID] = pruneHistory(append(s.history[stationID], img), now, s.retention)
+	count := len(s.history[stationID])
 	s.mu.Unlock()
 
 	logger.WithFields(map[string]string{
 		"station":      stationID,
 		"bytes":        fmt.Sprintf("%d", len(data)),
 		"content_type": contentType,
+		"history":      fmt.Sprintf("%d", count),
 	}).Debug("Stored radar image")
 
 	return img, nil
 }
 
-// Get returns the most recently cached image for the station, if any.
-func (s *Service) Get(stationID string) (*Image, bool) {
+// Latest returns the most recent image for the station, if any is still within
+// the retention window.
+func (s *Service) Latest(stationID string) (*Image, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	img, ok := s.cache[stationID]
-	return img, ok
+	imgs := s.history[stationID]
+	if len(imgs) == 0 {
+		return nil, false
+	}
+	return imgs[len(imgs)-1], true
 }
 
-// filenameFor builds a sensible attachment filename based on the content type.
-func filenameFor(stationID, contentType string) string {
+// History returns a copy of the cached images for the station ordered from
+// oldest to newest. Images outside the retention window are excluded.
+func (s *Service) History(stationID string) []*Image {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	imgs := s.history[stationID]
+	if len(imgs) == 0 {
+		return nil
+	}
+	out := make([]*Image, len(imgs))
+	copy(out, imgs)
+	return out
+}
+
+// pruneHistory drops entries whose FetchedAt is older than (now - retention)
+// and ensures the slice stays sorted oldest-first. Returns a slice that may
+// share backing storage with the input.
+func pruneHistory(imgs []*Image, now time.Time, retention time.Duration) []*Image {
+	if len(imgs) == 0 {
+		return imgs
+	}
+	// Keep order stable by FetchedAt; appends are normally already sorted
+	// but be defensive in case fetches complete out of order under load.
+	sort.SliceStable(imgs, func(i, j int) bool {
+		return imgs[i].FetchedAt.Before(imgs[j].FetchedAt)
+	})
+	cutoff := now.Add(-retention)
+	keepFrom := 0
+	for i, img := range imgs {
+		if !img.FetchedAt.Before(cutoff) {
+			keepFrom = i
+			break
+		}
+		keepFrom = i + 1
+	}
+	return imgs[keepFrom:]
+}
+
+// filenameFor builds a sensible attachment filename based on the content type
+// and fetch time so historical images do not collide.
+func filenameFor(stationID, contentType string, fetchedAt time.Time) string {
 	ext := "gif"
 	switch {
 	case strings.Contains(contentType, "png"):
@@ -138,5 +236,5 @@ func filenameFor(stationID, contentType string) string {
 	case strings.Contains(contentType, "gif"):
 		ext = "gif"
 	}
-	return fmt.Sprintf("%s.%s", stationID, ext)
+	return fmt.Sprintf("%s-%s.%s", stationID, fetchedAt.UTC().Format("20060102T150405Z"), ext)
 }

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -1,0 +1,105 @@
+package image
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestURLForUsesTemplate(t *testing.T) {
+	svc := New("https://example.com/{station}/img.gif")
+	got := svc.URLFor("KRAX")
+	want := "https://example.com/KRAX/img.gif"
+	if got != want {
+		t.Errorf("URLFor() = %q, want %q", got, want)
+	}
+}
+
+func TestURLForDefaultTemplate(t *testing.T) {
+	svc := New("")
+	got := svc.URLFor("KRAX")
+	if !strings.Contains(got, "KRAX") {
+		t.Errorf("URLFor() = %q, expected to contain KRAX", got)
+	}
+	if !strings.Contains(got, "radar.weather.gov") {
+		t.Errorf("URLFor() = %q, expected default NWS host", got)
+	}
+}
+
+func TestFetchStoresImageInCache(t *testing.T) {
+	body := []byte("GIF89a-fake-image-bytes")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/gif")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	svc := New(server.URL + "/{station}.gif")
+
+	img, err := svc.Fetch("KATX")
+	if err != nil {
+		t.Fatalf("Fetch() returned error: %v", err)
+	}
+	if img == nil {
+		t.Fatal("Fetch() returned nil image")
+	}
+	if string(img.Data) != string(body) {
+		t.Errorf("Fetch() data = %q, want %q", img.Data, body)
+	}
+	if img.ContentType != "image/gif" {
+		t.Errorf("Fetch() content type = %q, want image/gif", img.ContentType)
+	}
+	if img.Filename != "KATX.gif" {
+		t.Errorf("Fetch() filename = %q, want KATX.gif", img.Filename)
+	}
+
+	cached, ok := svc.Get("KATX")
+	if !ok {
+		t.Fatal("Get() returned no cached image after Fetch()")
+	}
+	if string(cached.Data) != string(body) {
+		t.Errorf("Get() data = %q, want %q", cached.Data, body)
+	}
+}
+
+func TestFetchReturnsErrorOnNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc := New(server.URL + "/{station}.gif")
+	if _, err := svc.Fetch("KATX"); err == nil {
+		t.Error("Fetch() expected error for 404 response, got nil")
+	}
+	if _, ok := svc.Get("KATX"); ok {
+		t.Error("Get() expected no cached image on failed fetch")
+	}
+}
+
+func TestFetchEmptyStationID(t *testing.T) {
+	svc := New("")
+	if _, err := svc.Fetch(""); err == nil {
+		t.Error("Fetch(\"\") expected error, got nil")
+	}
+}
+
+func TestFilenameForExtension(t *testing.T) {
+	tests := []struct {
+		contentType string
+		want        string
+	}{
+		{"image/gif", "K.gif"},
+		{"image/png", "K.png"},
+		{"image/jpeg", "K.jpg"},
+		{"image/jpg", "K.jpg"},
+		{"application/octet-stream", "K.gif"},
+	}
+	for _, tt := range tests {
+		got := filenameFor("K", tt.contentType)
+		if got != tt.want {
+			t.Errorf("filenameFor(_, %q) = %q, want %q", tt.contentType, got, tt.want)
+		}
+	}
+}

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestURLForUsesTemplate(t *testing.T) {
-	svc := New("https://example.com/{station}/img.gif")
+	svc := New(Config{URLTemplate: "https://example.com/{station}/img.gif"})
 	got := svc.URLFor("KRAX")
 	want := "https://example.com/KRAX/img.gif"
 	if got != want {
@@ -17,7 +18,7 @@ func TestURLForUsesTemplate(t *testing.T) {
 }
 
 func TestURLForDefaultTemplate(t *testing.T) {
-	svc := New("")
+	svc := New(Config{})
 	got := svc.URLFor("KRAX")
 	if !strings.Contains(got, "KRAX") {
 		t.Errorf("URLFor() = %q, expected to contain KRAX", got)
@@ -27,15 +28,29 @@ func TestURLForDefaultTemplate(t *testing.T) {
 	}
 }
 
-func TestFetchStoresImageInCache(t *testing.T) {
+func TestRetentionDefault(t *testing.T) {
+	svc := New(Config{})
+	if svc.Retention() != DefaultRetention {
+		t.Errorf("Retention() = %v, want %v", svc.Retention(), DefaultRetention)
+	}
+}
+
+func TestFetchSendsUserAgentAndStores(t *testing.T) {
 	body := []byte("GIF89a-fake-image-bytes")
+	const ua = "dras/test (+https://github.com/jacaudi/dras)"
+
+	var receivedUA string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUA = r.Header.Get("User-Agent")
 		w.Header().Set("Content-Type", "image/gif")
 		_, _ = w.Write(body)
 	}))
 	defer server.Close()
 
-	svc := New(server.URL + "/{station}.gif")
+	svc := New(Config{
+		URLTemplate: server.URL + "/{station}.gif",
+		UserAgent:   ua,
+	})
 
 	img, err := svc.Fetch("KATX")
 	if err != nil {
@@ -44,22 +59,74 @@ func TestFetchStoresImageInCache(t *testing.T) {
 	if img == nil {
 		t.Fatal("Fetch() returned nil image")
 	}
+	if receivedUA != ua {
+		t.Errorf("server saw User-Agent %q, want %q", receivedUA, ua)
+	}
 	if string(img.Data) != string(body) {
 		t.Errorf("Fetch() data = %q, want %q", img.Data, body)
 	}
 	if img.ContentType != "image/gif" {
 		t.Errorf("Fetch() content type = %q, want image/gif", img.ContentType)
 	}
-	if img.Filename != "KATX.gif" {
-		t.Errorf("Fetch() filename = %q, want KATX.gif", img.Filename)
+	if !strings.HasPrefix(img.Filename, "KATX-") || !strings.HasSuffix(img.Filename, ".gif") {
+		t.Errorf("Fetch() filename = %q, want KATX-<ts>.gif", img.Filename)
 	}
 
-	cached, ok := svc.Get("KATX")
+	cached, ok := svc.Latest("KATX")
 	if !ok {
-		t.Fatal("Get() returned no cached image after Fetch()")
+		t.Fatal("Latest() returned no cached image after Fetch()")
 	}
 	if string(cached.Data) != string(body) {
-		t.Errorf("Get() data = %q, want %q", cached.Data, body)
+		t.Errorf("Latest() data = %q, want %q", cached.Data, body)
+	}
+
+	history := svc.History("KATX")
+	if len(history) != 1 {
+		t.Errorf("History() length = %d, want 1", len(history))
+	}
+}
+
+func TestFetchAppendsHistoryAndPrunes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/gif")
+		_, _ = w.Write([]byte("frame"))
+	}))
+	defer server.Close()
+
+	svc := New(Config{
+		URLTemplate: server.URL + "/{station}.gif",
+		Retention:   2 * time.Hour,
+	})
+
+	// Seed three images, two of which fall outside the retention window.
+	now := time.Now()
+	svc.history["KATX"] = []*Image{
+		{StationID: "KATX", FetchedAt: now.Add(-3 * time.Hour), Data: []byte("old1")},
+		{StationID: "KATX", FetchedAt: now.Add(-150 * time.Minute), Data: []byte("old2")},
+		{StationID: "KATX", FetchedAt: now.Add(-30 * time.Minute), Data: []byte("recent")},
+	}
+
+	if _, err := svc.Fetch("KATX"); err != nil {
+		t.Fatalf("Fetch() returned error: %v", err)
+	}
+
+	history := svc.History("KATX")
+	if len(history) != 2 {
+		t.Fatalf("History() length = %d, want 2 (recent + just-fetched)", len(history))
+	}
+	if string(history[0].Data) != "recent" {
+		t.Errorf("history[0] data = %q, want %q", history[0].Data, "recent")
+	}
+	if string(history[1].Data) != "frame" {
+		t.Errorf("history[1] data = %q, want %q", history[1].Data, "frame")
+	}
+
+	latest, ok := svc.Latest("KATX")
+	if !ok {
+		t.Fatal("Latest() returned no image")
+	}
+	if string(latest.Data) != "frame" {
+		t.Errorf("Latest() data = %q, want %q", latest.Data, "frame")
 	}
 }
 
@@ -69,37 +136,38 @@ func TestFetchReturnsErrorOnNon200(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc := New(server.URL + "/{station}.gif")
+	svc := New(Config{URLTemplate: server.URL + "/{station}.gif"})
 	if _, err := svc.Fetch("KATX"); err == nil {
 		t.Error("Fetch() expected error for 404 response, got nil")
 	}
-	if _, ok := svc.Get("KATX"); ok {
-		t.Error("Get() expected no cached image on failed fetch")
+	if _, ok := svc.Latest("KATX"); ok {
+		t.Error("Latest() expected no cached image on failed fetch")
 	}
 }
 
 func TestFetchEmptyStationID(t *testing.T) {
-	svc := New("")
+	svc := New(Config{})
 	if _, err := svc.Fetch(""); err == nil {
 		t.Error("Fetch(\"\") expected error, got nil")
 	}
 }
 
 func TestFilenameForExtension(t *testing.T) {
+	ts := time.Date(2026, 4, 25, 12, 30, 45, 0, time.UTC)
 	tests := []struct {
 		contentType string
 		want        string
 	}{
-		{"image/gif", "K.gif"},
-		{"image/png", "K.png"},
-		{"image/jpeg", "K.jpg"},
-		{"image/jpg", "K.jpg"},
-		{"application/octet-stream", "K.gif"},
+		{"image/gif", "K-20260425T123045Z.gif"},
+		{"image/png", "K-20260425T123045Z.png"},
+		{"image/jpeg", "K-20260425T123045Z.jpg"},
+		{"image/jpg", "K-20260425T123045Z.jpg"},
+		{"application/octet-stream", "K-20260425T123045Z.gif"},
 	}
 	for _, tt := range tests {
-		got := filenameFor("K", tt.contentType)
+		got := filenameFor("K", tt.contentType, ts)
 		if got != tt.want {
-			t.Errorf("filenameFor(_, %q) = %q, want %q", tt.contentType, got, tt.want)
+			t.Errorf("filenameFor(_, %q, _) = %q, want %q", tt.contentType, got, tt.want)
 		}
 	}
 }

--- a/internal/monitor/benchmark_test.go
+++ b/internal/monitor/benchmark_test.go
@@ -29,14 +29,14 @@ func BenchmarkMonitorMemoryUsage(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			radarService := radar.New()
 			var notifyService *notify.Service // nil for dry run
-			_ = New(radarService, notifyService, cfg)
+			_ = New(radarService, notifyService, nil, cfg)
 		}
 	})
 
 	b.Run("DataMapGrowth", func(b *testing.B) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		stations := []string{"KATX", "KRAX", "KBGM", "KTLX", "KFFC"}
 
@@ -74,7 +74,7 @@ func BenchmarkConcurrentProcessing(b *testing.B) {
 	b.Run("SingleStation", func(b *testing.B) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -97,7 +97,7 @@ func BenchmarkConcurrentProcessing(b *testing.B) {
 	b.Run("MultipleStations", func(b *testing.B) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		stations := []string{"KATX", "KRAX", "KBGM", "KTLX", "KFFC"}
 

--- a/internal/monitor/concurrency_test.go
+++ b/internal/monitor/concurrency_test.go
@@ -23,7 +23,7 @@ func TestConcurrentStationProcessing(t *testing.T) {
 	t.Run("concurrent data access", func(t *testing.T) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		stations := []string{"KATX", "KRAX", "KBGM", "KTLX", "KFFC"}
 		var wg sync.WaitGroup
@@ -64,7 +64,7 @@ func TestConcurrentStationProcessing(t *testing.T) {
 	t.Run("concurrent read/write operations", func(t *testing.T) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		// Pre-populate the data map
 		monitor.mu.Lock()
@@ -160,7 +160,7 @@ func TestGoroutineErrorHandling(t *testing.T) {
 		// In our current implementation, goroutines return errors instead of panicking
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		var wg sync.WaitGroup
 		errorCount := 0
@@ -209,7 +209,7 @@ func TestMonitorStartStop(t *testing.T) {
 	t.Run("start and cancel", func(t *testing.T) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jacaudi/dras/internal/config"
+	"github.com/jacaudi/dras/internal/image"
 	"github.com/jacaudi/dras/internal/logger"
 	"github.com/jacaudi/dras/internal/notify"
 	"github.com/jacaudi/dras/internal/radar"
@@ -16,16 +17,19 @@ import (
 type Monitor struct {
 	radarService  *radar.Service
 	notifyService *notify.Service
+	imageService  *image.Service
 	config        *config.Config
 	radarDataMap  map[string]map[string]interface{}
 	mu            sync.Mutex
 }
 
-// New creates a new monitor instance.
-func New(radarService *radar.Service, notifyService *notify.Service, cfg *config.Config) *Monitor {
+// New creates a new monitor instance. imageService may be nil to disable
+// fetching and attaching radar images.
+func New(radarService *radar.Service, notifyService *notify.Service, imageService *image.Service, cfg *config.Config) *Monitor {
 	return &Monitor{
 		radarService:  radarService,
 		notifyService: notifyService,
+		imageService:  imageService,
 		config:        cfg,
 		radarDataMap:  make(map[string]map[string]interface{}),
 	}
@@ -100,6 +104,11 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 		return fmt.Errorf("error determining radar mode for station %s: %w", stationID, err)
 	}
 
+	// Poll and store the latest radar image so it can be attached to the
+	// next change notification. Image fetch failures are logged but do not
+	// fail the whole poll.
+	radarImage := m.fetchRadarImage(stationID, stationLogger)
+
 	// Check if we need to initialize or if this is first run
 	m.mu.Lock()
 	if _, exists := m.radarDataMap[stationID]; !exists {
@@ -144,10 +153,14 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 			"change":       changeMessage,
 		}).Info("Radar data changed")
 
+		vcpChanged := lastData.VCP != newRadarData.VCP
+
 		if m.config.DryRun {
 			stationLogger.Debug("Would send change notification: %s", changeMessage)
 		} else {
-			if err := m.notifyService.SendNotification(ctx, fmt.Sprintf("%s Update", stationID), changeMessage); err != nil {
+			title := fmt.Sprintf("%s Update", stationID)
+			attachment := m.attachmentForChange(stationID, vcpChanged, radarImage, stationLogger)
+			if err := m.notifyService.SendNotificationWithAttachment(ctx, title, changeMessage, attachment); err != nil {
 				return fmt.Errorf("failed to send change notification for station %s: %w", stationID, err)
 			}
 			stationLogger.Info("Change notification sent successfully")
@@ -160,4 +173,47 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 	}
 
 	return nil
+}
+
+// fetchRadarImage downloads and caches the latest radar image for the given
+// station. Returns nil if image fetching is disabled or the download fails.
+func (m *Monitor) fetchRadarImage(stationID string, stationLogger *logger.FieldLogger) *image.Image {
+	if m.imageService == nil {
+		return nil
+	}
+
+	img, err := m.imageService.Fetch(stationID)
+	if err != nil {
+		stationLogger.Warn("Failed to fetch radar image: %v", err)
+		return nil
+	}
+	return img
+}
+
+// attachmentForChange returns the radar image to attach to a change
+// notification, or nil when no attachment should be sent. Images are only
+// attached when the VCP changed, matching the user-facing feature scope.
+func (m *Monitor) attachmentForChange(stationID string, vcpChanged bool, justFetched *image.Image, stationLogger *logger.FieldLogger) *notify.Attachment {
+	if !vcpChanged || m.imageService == nil {
+		return nil
+	}
+
+	img := justFetched
+	if img == nil {
+		// Fall back to the most recently cached image if the latest poll
+		// failed to download a fresh one.
+		if cached, ok := m.imageService.Get(stationID); ok {
+			img = cached
+		}
+	}
+	if img == nil {
+		stationLogger.Debug("VCP changed but no radar image available to attach")
+		return nil
+	}
+
+	return &notify.Attachment{
+		Data:        img.Data,
+		ContentType: img.ContentType,
+		Filename:    img.Filename,
+	}
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -15,8 +15,8 @@ import (
 
 // Monitor handles the monitoring logic for radar stations.
 type Monitor struct {
-	radarService  *radar.Service
-	notifyService *notify.Service
+	radarService  radar.DataFetcher
+	notifyService notify.Notifier
 	imageService  *image.Service
 	config        *config.Config
 	radarDataMap  map[string]map[string]interface{}
@@ -24,8 +24,9 @@ type Monitor struct {
 }
 
 // New creates a new monitor instance. imageService may be nil to disable
-// fetching and attaching radar images.
-func New(radarService *radar.Service, notifyService *notify.Service, imageService *image.Service, cfg *config.Config) *Monitor {
+// fetching and attaching radar images. notifyService may also be nil when
+// running in dry-run mode.
+func New(radarService radar.DataFetcher, notifyService notify.Notifier, imageService *image.Service, cfg *config.Config) *Monitor {
 	return &Monitor{
 		radarService:  radarService,
 		notifyService: notifyService,

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -202,7 +202,7 @@ func (m *Monitor) attachmentForChange(stationID string, vcpChanged bool, justFet
 	if img == nil {
 		// Fall back to the most recently cached image if the latest poll
 		// failed to download a fresh one.
-		if cached, ok := m.imageService.Get(stationID); ok {
+		if cached, ok := m.imageService.Latest(stationID); ok {
 			img = cached
 		}
 	}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,262 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jacaudi/dras/internal/config"
+	"github.com/jacaudi/dras/internal/image"
+	"github.com/jacaudi/dras/internal/logger"
+	"github.com/jacaudi/dras/internal/notify"
+	"github.com/jacaudi/dras/internal/radar"
+)
+
+func TestFetchRadarImageNilService(t *testing.T) {
+	m := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), nil, &config.Config{})
+
+	got := m.fetchRadarImage("KATX", logger.WithField("station", "KATX"))
+	if got != nil {
+		t.Errorf("fetchRadarImage() = %v, want nil when image service is nil", got)
+	}
+}
+
+func TestFetchRadarImageReturnsNilOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	imgSvc := image.New(image.Config{URLTemplate: server.URL + "/{station}.gif"})
+	m := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), imgSvc, &config.Config{})
+
+	got := m.fetchRadarImage("KATX", logger.WithField("station", "KATX"))
+	if got != nil {
+		t.Errorf("fetchRadarImage() = %v, want nil on HTTP failure", got)
+	}
+}
+
+func TestAttachmentForChange(t *testing.T) {
+	body := []byte("GIF89a-fake")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/gif")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	imgSvc := image.New(image.Config{URLTemplate: server.URL + "/{station}.gif"})
+	m := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), imgSvc, &config.Config{})
+	stationLogger := logger.WithField("station", "KATX")
+
+	t.Run("returns nil when VCP did not change", func(t *testing.T) {
+		fresh, err := imgSvc.Fetch("KATX")
+		if err != nil {
+			t.Fatalf("Fetch() error: %v", err)
+		}
+		got := m.attachmentForChange("KATX", false, fresh, stationLogger)
+		if got != nil {
+			t.Errorf("attachmentForChange() = %v, want nil when VCP unchanged", got)
+		}
+	})
+
+	t.Run("returns attachment with fresh image when VCP changed", func(t *testing.T) {
+		fresh, err := imgSvc.Fetch("KATX")
+		if err != nil {
+			t.Fatalf("Fetch() error: %v", err)
+		}
+		got := m.attachmentForChange("KATX", true, fresh, stationLogger)
+		if got == nil {
+			t.Fatal("attachmentForChange() = nil, want attachment")
+		}
+		if string(got.Data) != string(body) {
+			t.Errorf("attachment data = %q, want %q", got.Data, body)
+		}
+		if got.ContentType != "image/gif" {
+			t.Errorf("attachment content type = %q, want image/gif", got.ContentType)
+		}
+	})
+
+	t.Run("falls back to cached image when fresh fetch failed", func(t *testing.T) {
+		// imgSvc still has a cached image from the prior subtest. Pass nil as
+		// the just-fetched image to simulate a failed download.
+		got := m.attachmentForChange("KATX", true, nil, stationLogger)
+		if got == nil {
+			t.Fatal("attachmentForChange() = nil, want fallback to cached image")
+		}
+		if string(got.Data) != string(body) {
+			t.Errorf("attachment data = %q, want cached %q", got.Data, body)
+		}
+	})
+
+	t.Run("returns nil when no image is available", func(t *testing.T) {
+		got := m.attachmentForChange("KUNKNOWN", true, nil, stationLogger)
+		if got != nil {
+			t.Errorf("attachmentForChange() = %v, want nil for unknown station with no cache", got)
+		}
+	})
+
+	t.Run("returns nil when image service is disabled", func(t *testing.T) {
+		mNoImg := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), nil, &config.Config{})
+		fresh, err := imgSvc.Fetch("KATX")
+		if err != nil {
+			t.Fatalf("Fetch() error: %v", err)
+		}
+		got := mNoImg.attachmentForChange("KATX", true, fresh, stationLogger)
+		if got != nil {
+			t.Errorf("attachmentForChange() = %v, want nil when image service is disabled", got)
+		}
+	})
+}
+
+// TestVCPChangeDeliversAttachment is an end-to-end test that wires together a
+// fake radar source, a real image service backed by httptest, and a mock
+// notifier to verify that a VCP change between two polls triggers a
+// notification with the just-downloaded radar image attached.
+func TestVCPChangeDeliversAttachment(t *testing.T) {
+	// Image server returns a unique body per request so we can tell which
+	// image was attached.
+	var imageRequests int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&imageRequests, 1)
+		w.Header().Set("Content-Type", "image/gif")
+		w.Write([]byte{'G', 'I', 'F', byte('0' + n)})
+	}))
+	defer server.Close()
+
+	imgSvc := image.New(image.Config{
+		URLTemplate: server.URL + "/{station}.gif",
+		Retention:   time.Hour,
+		UserAgent:   "dras/test",
+	})
+
+	radarMock := radar.NewMockDataFetcher()
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R31", Mode: "Clear Air",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Utility", GenState: "Off",
+	})
+
+	notifyMock := notify.NewMockNotifier()
+
+	cfg := &config.Config{
+		DryRun:        false,
+		CheckInterval: time.Minute,
+		AlertConfig:   radar.AlertConfig{VCP: true},
+	}
+
+	m := New(radarMock, notifyMock, imgSvc, cfg)
+	ctx := context.Background()
+
+	// First poll seeds the cache and triggers the startup notification.
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("first processStation() error: %v", err)
+	}
+
+	startupNotifs := notifyMock.GetNotifications()
+	if len(startupNotifs) != 1 || startupNotifs[0].Title != "DRAS Startup" {
+		t.Fatalf("expected startup notification, got %+v", startupNotifs)
+	}
+	if startupNotifs[0].Attachment != nil {
+		t.Errorf("startup notification should not have an attachment, got %+v", startupNotifs[0].Attachment)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 1 {
+		t.Errorf("expected 1 image request after first poll, got %d", got)
+	}
+
+	// Second poll: VCP changes from R31 (Clear Air) to R12 (Precipitation).
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R12", Mode: "Precipitation",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Utility", GenState: "Off",
+	})
+
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("second processStation() error: %v", err)
+	}
+
+	notifs := notifyMock.GetNotifications()
+	if len(notifs) != 2 {
+		t.Fatalf("expected 2 notifications, got %d (%+v)", len(notifs), notifs)
+	}
+
+	change := notifs[1]
+	if change.Title != "KATX Update" {
+		t.Errorf("change notification title = %q, want %q", change.Title, "KATX Update")
+	}
+	if change.Attachment == nil {
+		t.Fatal("change notification has no attachment")
+	}
+	// Second image request returns "GIF2" — the freshest poll.
+	want := []byte{'G', 'I', 'F', '2'}
+	if string(change.Attachment.Data) != string(want) {
+		t.Errorf("attachment data = %q, want %q (freshest image)", change.Attachment.Data, want)
+	}
+	if change.Attachment.ContentType != "image/gif" {
+		t.Errorf("attachment content type = %q, want image/gif", change.Attachment.ContentType)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 2 {
+		t.Errorf("expected 2 image requests total, got %d", got)
+	}
+
+	// History should contain both polls' images.
+	history := imgSvc.History("KATX")
+	if len(history) != 2 {
+		t.Errorf("expected 2 images in history, got %d", len(history))
+	}
+}
+
+// TestNonVCPChangeOmitsAttachment verifies that changes which are not VCP
+// changes (e.g. power source) do not attach the radar image, matching the
+// user-facing scope of the feature.
+func TestNonVCPChangeOmitsAttachment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/gif")
+		w.Write([]byte("img"))
+	}))
+	defer server.Close()
+
+	imgSvc := image.New(image.Config{URLTemplate: server.URL + "/{station}.gif"})
+	radarMock := radar.NewMockDataFetcher()
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R31", Mode: "Clear Air",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Utility", GenState: "Off",
+	})
+
+	notifyMock := notify.NewMockNotifier()
+	cfg := &config.Config{
+		DryRun:        false,
+		CheckInterval: time.Minute,
+		AlertConfig:   radar.AlertConfig{VCP: true, PowerSource: true},
+	}
+
+	m := New(radarMock, notifyMock, imgSvc, cfg)
+	ctx := context.Background()
+
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("first processStation() error: %v", err)
+	}
+
+	// Change only the power source, not the VCP.
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R31", Mode: "Clear Air",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Generator", GenState: "On",
+	})
+
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("second processStation() error: %v", err)
+	}
+
+	notifs := notifyMock.GetNotifications()
+	if len(notifs) != 2 {
+		t.Fatalf("expected 2 notifications, got %d", len(notifs))
+	}
+	change := notifs[1]
+	if change.Attachment != nil {
+		t.Errorf("non-VCP change should not have attachment, got %+v", change.Attachment)
+	}
+}

--- a/internal/monitor/race_test.go
+++ b/internal/monitor/race_test.go
@@ -33,7 +33,7 @@ func TestRaceConditions(t *testing.T) {
 	t.Run("concurrent map access race detection", func(t *testing.T) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		stations := []string{"KATX", "KRAX", "KBGM", "KTLX", "KFFC"}
 		var wg sync.WaitGroup
@@ -83,7 +83,7 @@ func TestRaceConditions(t *testing.T) {
 	t.Run("concurrent read/write race detection", func(t *testing.T) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		// Initialize some data
 		monitor.mu.Lock()
@@ -151,7 +151,7 @@ func TestRaceConditions(t *testing.T) {
 	t.Run("stress test with high concurrency", func(t *testing.T) {
 		radarService := radar.New()
 		var notifyService *notify.Service
-		monitor := New(radarService, notifyService, cfg)
+		monitor := New(radarService, notifyService, nil, cfg)
 
 		stations := []string{"KATX", "KRAX", "KBGM", "KTLX", "KFFC", "KJAX", "KMLB", "KTBW", "KMHX", "KAKQ"}
 		var wg sync.WaitGroup
@@ -204,7 +204,7 @@ func TestRaceWithRealMonitoring(t *testing.T) {
 
 	radarService := radar.New()
 	var notifyService *notify.Service
-	monitor := New(radarService, notifyService, cfg)
+	monitor := New(radarService, notifyService, nil, cfg)
 
 	// Start the monitor in a goroutine
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)

--- a/internal/notify/interfaces.go
+++ b/internal/notify/interfaces.go
@@ -8,6 +8,7 @@ import (
 // Notifier interface for abstracting notification sending
 type Notifier interface {
 	SendNotification(ctx context.Context, title, message string) error
+	SendNotificationWithAttachment(ctx context.Context, title, message string, attachment *Attachment) error
 }
 
 // MockNotifier provides a mock implementation for testing
@@ -20,8 +21,9 @@ type MockNotifier struct {
 
 // Notification represents a sent notification for testing
 type Notification struct {
-	Title   string
-	Message string
+	Title      string
+	Message    string
+	Attachment *Attachment
 }
 
 // NewMockNotifier creates a new mock notifier
@@ -34,6 +36,13 @@ func NewMockNotifier() *MockNotifier {
 
 // SendNotification simulates sending a notification
 func (m *MockNotifier) SendNotification(ctx context.Context, title, message string) error {
+	return m.SendNotificationWithAttachment(ctx, title, message, nil)
+}
+
+// SendNotificationWithAttachment simulates sending a notification that may
+// include an image attachment. The attachment pointer is recorded as-is so
+// tests can assert on it.
+func (m *MockNotifier) SendNotificationWithAttachment(ctx context.Context, title, message string, attachment *Attachment) error {
 	m.callCount++
 
 	if m.shouldError {
@@ -45,8 +54,9 @@ func (m *MockNotifier) SendNotification(ctx context.Context, title, message stri
 	}
 
 	m.notifications = append(m.notifications, Notification{
-		Title:   title,
-		Message: message,
+		Title:      title,
+		Message:    message,
+		Attachment: attachment,
 	})
 
 	return nil

--- a/internal/notify/pushover.go
+++ b/internal/notify/pushover.go
@@ -1,15 +1,24 @@
 package notify
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"regexp"
 
+	"github.com/gregdel/pushover"
 	"github.com/jacaudi/dras/internal/logger"
 	"github.com/nikoksr/notify"
-	"github.com/nikoksr/notify/service/pushover"
+	pushoverNotify "github.com/nikoksr/notify/service/pushover"
 )
+
+// Attachment is an optional image to include with a Pushover notification.
+type Attachment struct {
+	Data        []byte
+	ContentType string
+	Filename    string
+}
 
 // Service handles notification operations and implements the Notifier interface.
 type Service struct {
@@ -91,7 +100,7 @@ func ValidateUserKey(userKey string) error {
 // The function returns an error if the notification fails to send, otherwise it returns nil.
 func (s *Service) SendNotification(ctx context.Context, title, message string) error {
 	// Create a new Pushover service
-	pushoverService := pushover.New(s.apiToken)
+	pushoverService := pushoverNotify.New(s.apiToken)
 
 	// Add a recipient
 	pushoverService.AddReceivers(s.userKey)
@@ -107,5 +116,44 @@ func (s *Service) SendNotification(ctx context.Context, title, message string) e
 	}
 
 	logger.Debug("Pushover notification sent successfully")
+	return nil
+}
+
+// SendNotificationWithAttachment sends a Pushover notification that includes
+// an image attachment. When attachment is nil this is equivalent to
+// SendNotification. The Pushover REST API is invoked directly because the
+// nikoksr/notify wrapper does not expose attachment support.
+func (s *Service) SendNotificationWithAttachment(ctx context.Context, title, message string, attachment *Attachment) error {
+	if attachment == nil || len(attachment.Data) == 0 {
+		return s.SendNotification(ctx, title, message)
+	}
+
+	app := pushover.New(s.apiToken)
+	recipient := pushover.NewRecipient(s.userKey)
+
+	msg := pushover.NewMessageWithTitle(message, title)
+	if err := msg.AddAttachment(bytes.NewReader(attachment.Data)); err != nil {
+		return fmt.Errorf("failed to attach image to notification: %w", err)
+	}
+
+	type result struct {
+		err error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		_, err := app.SendMessage(msg, recipient)
+		resCh <- result{err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case r := <-resCh:
+		if r.err != nil {
+			return r.err
+		}
+	}
+
+	logger.WithField("bytes", fmt.Sprintf("%d", len(attachment.Data))).Debug("Pushover notification with attachment sent successfully")
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -48,9 +48,10 @@ func main() {
 	}).Debug("Runtime configuration")
 
 	// Set NWS UserAgent
-	logger.Info("Setting NWS UserAgent to https://github.com/jacaudi/dras")
+	userAgent := fmt.Sprintf("dras/%s (+https://github.com/jacaudi/dras)", versionInfo.Version)
+	logger.Info("Setting NWS UserAgent to %s", userAgent)
 	nwsConfig := nws.Config{}
-	nwsConfig.SetUserAgent("dras/1.0 (+https://github.com/jacaudi/dras)")
+	nwsConfig.SetUserAgent(userAgent)
 
 	// Initialize services
 	radarService := radar.New()
@@ -71,8 +72,15 @@ func main() {
 	// Initialize image service for polling and attaching radar images on VCP changes
 	var imageService *image.Service
 	if cfg.RadarImageEnabled {
-		imageService = image.New(cfg.RadarImageURLTmpl)
-		logger.WithField("url_template", imageService.URLFor("{station}")).Info("Radar image polling enabled")
+		imageService = image.New(image.Config{
+			URLTemplate: cfg.RadarImageURLTmpl,
+			Retention:   cfg.RadarImageRetention,
+			UserAgent:   userAgent,
+		})
+		logger.WithFields(map[string]string{
+			"url_template": imageService.URLFor("{station}"),
+			"retention":    cfg.RadarImageRetention.String(),
+		}).Info("Radar image polling enabled")
 	} else {
 		logger.Info("Radar image polling disabled")
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jacaudi/dras/internal/config"
+	"github.com/jacaudi/dras/internal/image"
 	"github.com/jacaudi/dras/internal/logger"
 	"github.com/jacaudi/dras/internal/monitor"
 	"github.com/jacaudi/dras/internal/notify"
@@ -67,8 +68,17 @@ func main() {
 		logger.Info("Running in dry-run mode, notifications disabled")
 	}
 
+	// Initialize image service for polling and attaching radar images on VCP changes
+	var imageService *image.Service
+	if cfg.RadarImageEnabled {
+		imageService = image.New(cfg.RadarImageURLTmpl)
+		logger.WithField("url_template", imageService.URLFor("{station}")).Info("Radar image polling enabled")
+	} else {
+		logger.Info("Radar image polling disabled")
+	}
+
 	// Initialize monitor
-	monitorService := monitor.New(radarService, notifyService, cfg)
+	monitorService := monitor.New(radarService, notifyService, imageService, cfg)
 
 	// Start monitoring
 	logger.Info("Starting radar monitoring service")

--- a/main_test.go
+++ b/main_test.go
@@ -67,7 +67,7 @@ func TestMainIntegration(t *testing.T) {
 			}
 
 			// Initialize monitor
-			monitorService := monitor.New(radarService, notifyService, cfg)
+			monitorService := monitor.New(radarService, notifyService, nil, cfg)
 			if monitorService == nil {
 				t.Error("Expected monitor service to be initialized")
 			}
@@ -106,7 +106,7 @@ func TestMainIntegration(t *testing.T) {
 			}
 
 			// Initialize monitor
-			monitorService := monitor.New(radarService, notifyService, cfg)
+			monitorService := monitor.New(radarService, notifyService, nil, cfg)
 			if monitorService == nil {
 				t.Error("Expected monitor service to be initialized")
 			}


### PR DESCRIPTION
Each poll now downloads the latest radar image (default
https://radar.weather.gov/ridge/standard/{station}_0.gif) into an
in-memory cache. When a VCP change is detected, the freshly downloaded
image is attached to the Pushover notification via the gregdel/pushover
library, since the nikoksr/notify wrapper does not expose attachment
support.

New env vars:
  RADAR_IMAGE_ENABLED       (default: true)
  RADAR_IMAGE_URL_TEMPLATE  (default: NWS Ridge GIF, {station} placeholder)

https://claude.ai/code/session_01DVXMAoGRYGSX1AUaCTyujP