### PR TITLE
fix: post-merge polish from issue #85

### DIFF
--- a/dras/internal/image/image.go
+++ b/dras/internal/image/image.go
@@ -3,6 +3,7 @@
 package image
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -45,8 +46,9 @@ type Image struct {
 // Source supplies radar images for stations. Implementations decide where
 // images come from (downloaded GIFs, rendered Level II data, etc).
 type Source interface {
-	// Fetch returns the latest image for the station.
-	Fetch(stationID string) (*Image, error)
+	// Fetch returns the latest image for the station. The context controls
+	// the entire fetch lifecycle, including any HTTP round-trip.
+	Fetch(ctx context.Context, stationID string) (*Image, error)
 	// Latest returns the most recent successful image for the station, if
 	// any is still within the implementation's retention window.
 	Latest(stationID string) (*Image, bool)
@@ -120,8 +122,9 @@ func (s *Service) URLFor(stationID string) string {
 
 // Fetch downloads the radar image for the station, appends it to the per
 // -station history, prunes images outside the retention window, and returns
-// the freshly downloaded image so callers can use it immediately.
-func (s *Service) Fetch(stationID string) (*Image, error) {
+// the freshly downloaded image so callers can use it immediately. The
+// supplied ctx controls the HTTP round-trip lifecycle.
+func (s *Service) Fetch(ctx context.Context, stationID string) (*Image, error) {
 	if stationID == "" {
 		return nil, errors.New("stationID cannot be empty")
 	}
@@ -132,7 +135,7 @@ func (s *Service) Fetch(stationID string) (*Image, error) {
 		"url":     url,
 	}).Debug("Fetching radar image")
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error building radar image request for %s: %w", stationID, err)
 	}

--- a/dras/internal/image/image_test.go
+++ b/dras/internal/image/image_test.go
@@ -52,7 +52,7 @@ func TestFetchSendsUserAgentAndStores(t *testing.T) {
 		UserAgent:   ua,
 	})
 
-	img, err := svc.Fetch("KATX")
+	img, err := svc.Fetch(t.Context(), "KATX")
 	if err != nil {
 		t.Fatalf("Fetch() returned error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestFetchAppendsHistoryAndPrunes(t *testing.T) {
 		{StationID: "KATX", FetchedAt: now.Add(-30 * time.Minute), Data: []byte("recent")},
 	}
 
-	if _, err := svc.Fetch("KATX"); err != nil {
+	if _, err := svc.Fetch(t.Context(), "KATX"); err != nil {
 		t.Fatalf("Fetch() returned error: %v", err)
 	}
 
@@ -137,7 +137,7 @@ func TestFetchReturnsErrorOnNon200(t *testing.T) {
 	defer server.Close()
 
 	svc := New(Config{URLTemplate: server.URL + "/{station}.gif"})
-	if _, err := svc.Fetch("KATX"); err == nil {
+	if _, err := svc.Fetch(t.Context(), "KATX"); err == nil {
 		t.Error("Fetch() expected error for 404 response, got nil")
 	}
 	if _, ok := svc.Latest("KATX"); ok {
@@ -147,7 +147,7 @@ func TestFetchReturnsErrorOnNon200(t *testing.T) {
 
 func TestFetchEmptyStationID(t *testing.T) {
 	svc := New(Config{})
-	if _, err := svc.Fetch(""); err == nil {
+	if _, err := svc.Fetch(t.Context(), ""); err == nil {
 		t.Error("Fetch(\"\") expected error, got nil")
 	}
 }

--- a/dras/internal/monitor/monitor.go
+++ b/dras/internal/monitor/monitor.go
@@ -108,7 +108,7 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 	// Poll and store the latest radar image so it can be attached to the
 	// next change notification. Image fetch failures are logged but do not
 	// fail the whole poll.
-	radarImage := m.fetchRadarImage(stationID, stationLogger)
+	radarImage := m.fetchRadarImage(ctx, stationID, stationLogger)
 
 	// Check if we need to initialize or if this is first run
 	m.mu.Lock()
@@ -179,12 +179,12 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 
 // fetchRadarImage downloads and caches the latest radar image for the given
 // station. Returns nil if image fetching is disabled or the download fails.
-func (m *Monitor) fetchRadarImage(stationID string, stationLogger *logger.FieldLogger) *image.Image {
+func (m *Monitor) fetchRadarImage(ctx context.Context, stationID string, stationLogger *logger.FieldLogger) *image.Image {
 	if m.imageService == nil {
 		return nil
 	}
 
-	img, err := m.imageService.Fetch(stationID)
+	img, err := m.imageService.Fetch(ctx, stationID)
 	if err != nil {
 		stationLogger.Warn("Failed to fetch radar image: %v", err)
 		return nil

--- a/dras/internal/monitor/monitor_test.go
+++ b/dras/internal/monitor/monitor_test.go
@@ -21,7 +21,7 @@ import (
 func TestFetchRadarImageNilService(t *testing.T) {
 	m := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), nil, &config.Config{})
 
-	got := m.fetchRadarImage("KATX", logger.WithField("station", "KATX"))
+	got := m.fetchRadarImage(t.Context(), "KATX", logger.WithField("station", "KATX"))
 	if got != nil {
 		t.Errorf("fetchRadarImage() = %v, want nil when image service is nil", got)
 	}
@@ -36,7 +36,7 @@ func TestFetchRadarImageReturnsNilOnFailure(t *testing.T) {
 	imgSvc := image.New(image.Config{URLTemplate: server.URL + "/{station}.gif"})
 	m := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), imgSvc, &config.Config{})
 
-	got := m.fetchRadarImage("KATX", logger.WithField("station", "KATX"))
+	got := m.fetchRadarImage(t.Context(), "KATX", logger.WithField("station", "KATX"))
 	if got != nil {
 		t.Errorf("fetchRadarImage() = %v, want nil on HTTP failure", got)
 	}
@@ -55,7 +55,7 @@ func TestAttachmentForChange(t *testing.T) {
 	stationLogger := logger.WithField("station", "KATX")
 
 	t.Run("returns nil when VCP did not change", func(t *testing.T) {
-		fresh, err := imgSvc.Fetch("KATX")
+		fresh, err := imgSvc.Fetch(t.Context(), "KATX")
 		if err != nil {
 			t.Fatalf("Fetch() error: %v", err)
 		}
@@ -66,7 +66,7 @@ func TestAttachmentForChange(t *testing.T) {
 	})
 
 	t.Run("returns attachment with fresh image when VCP changed", func(t *testing.T) {
-		fresh, err := imgSvc.Fetch("KATX")
+		fresh, err := imgSvc.Fetch(t.Context(), "KATX")
 		if err != nil {
 			t.Fatalf("Fetch() error: %v", err)
 		}
@@ -103,7 +103,7 @@ func TestAttachmentForChange(t *testing.T) {
 
 	t.Run("returns nil when image service is disabled", func(t *testing.T) {
 		mNoImg := New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), nil, &config.Config{})
-		fresh, err := imgSvc.Fetch("KATX")
+		fresh, err := imgSvc.Fetch(t.Context(), "KATX")
 		if err != nil {
 			t.Fatalf("Fetch() error: %v", err)
 		}

--- a/dras/internal/renderer/client.go
+++ b/dras/internal/renderer/client.go
@@ -53,10 +53,10 @@ func New(cfg Config) *Client {
 	}
 }
 
-// Fetch retrieves the rendered image for the station.
-func (c *Client) Fetch(stationID string) (*image.Image, error) {
+// Fetch retrieves the rendered image for the station. The supplied ctx controls
+// the entire HTTP round-trip lifecycle.
+func (c *Client) Fetch(ctx context.Context, stationID string) (*image.Image, error) {
 	url := fmt.Sprintf("%s/render/%s", c.baseURL, stationID)
-	ctx := context.Background()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/dras/internal/renderer/client_test.go
+++ b/dras/internal/renderer/client_test.go
@@ -1,8 +1,10 @@
 package renderer
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,7 +36,7 @@ func TestFetchHappyPath(t *testing.T) {
 	defer srv.Close()
 
 	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
-	img, err := c.Fetch("KATX")
+	img, err := c.Fetch(t.Context(), "KATX")
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestFetchServerErrorReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
-	_, err := c.Fetch("KATX")
+	_, err := c.Fetch(t.Context(), "KATX")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -76,7 +78,7 @@ func TestFetchTimeout(t *testing.T) {
 	defer srv.Close()
 
 	c := New(Config{BaseURL: srv.URL, Timeout: 100 * time.Millisecond})
-	_, err := c.Fetch("KATX")
+	_, err := c.Fetch(t.Context(), "KATX")
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -90,7 +92,7 @@ func TestFetchMalformedBody(t *testing.T) {
 	defer srv.Close()
 
 	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
-	_, err := c.Fetch("KATX")
+	_, err := c.Fetch(t.Context(), "KATX")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -104,7 +106,7 @@ func TestFetchBadBase64(t *testing.T) {
 	defer srv.Close()
 
 	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
-	_, err := c.Fetch("KATX")
+	_, err := c.Fetch(t.Context(), "KATX")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -119,3 +121,28 @@ func TestLatestAlwaysReturnsFalse(t *testing.T) {
 
 // Compile-time check that *Client satisfies image.Source.
 var _ image.Source = (*Client)(nil)
+
+func TestFetchPropagatesContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Server blocks until its request context is cancelled, so the only way out
+	// is through ctx propagation.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		http.Error(w, "ctx cancelled", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel — ctx is already done before Fetch starts.
+
+	_, err := c.Fetch(ctx, "KATX")
+	if err == nil {
+		t.Fatal("expected error from cancelled ctx, got nil")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/renderer/Dockerfile
+++ b/renderer/Dockerfile
@@ -27,12 +27,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /usr/local/bin/uv
 
 WORKDIR /app
+# Two-stage uv sync, by design — DO NOT consolidate:
+#   1. dependency-only sync (skips the local project) cached on
+#      pyproject.toml + uv.lock; reused as long as deps don't change.
+#   2. full sync (after src/ + README copies) installs the local package
+#      itself. README is required because hatchling reads it for the
+#      editable build's metadata.
+# Collapsing into a single COPY+sync invalidates the heavy dep layer on
+# every src change.
 COPY pyproject.toml uv.lock /app/
-# Dependency-only sync: skip the local project so hatchling doesn't try to
-# read README.md (which we haven't COPYed yet) for the editable build.
 RUN uv sync --frozen --no-dev --no-install-project
 
-# Copy source + README after dependency install for better layer caching.
 COPY src /app/src
 COPY README.md /app/README.md
 RUN uv sync --frozen --no-dev
@@ -74,6 +79,18 @@ WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 # Copy the warmed Cartopy cache and chown it for the renderer user.
 COPY --from=builder --chown=renderer:renderer /root/.local/share/cartopy /home/renderer/.local/share/cartopy
+# Verify the runtime user can actually read the cached Natural Earth data.
+# Run as the renderer UID (not root) so a future ownership/perms regression
+# in the COPY --chown above is caught at build time, not at first request.
+USER renderer
+RUN HOME=/home/renderer /app/.venv/bin/python -c "\
+import cartopy.feature as cf;\
+states=list(cf.STATES.with_scale('50m').geometries());\
+coast=list(cf.COASTLINE.with_scale('50m').geometries());\
+assert states and coast, 'cartopy cache copy is empty or unreachable';\
+print(f'cartopy cache verified: {len(states)} states, {len(coast)} coastline features')\
+"
+USER root
 COPY --chown=renderer:renderer src /app/src
 
 USER renderer

--- a/renderer/src/dras_renderer/app.py
+++ b/renderer/src/dras_renderer/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import time
+from datetime import datetime
 from typing import cast
 
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -15,7 +16,7 @@ from starlette.responses import Response
 
 from dras_renderer.cache import RenderCache
 from dras_renderer.config import Config
-from dras_renderer.metrics import REGISTRY, RENDER_DURATION, REQUESTS_TOTAL, S3_ERRORS_TOTAL
+from dras_renderer.metrics import REGISTRY, RENDER_DURATION, REQUESTS_TOTAL
 from dras_renderer.s3 import S3Client
 from dras_renderer.service import (
     RenderRequest,
@@ -38,7 +39,7 @@ _STATUS_FOR_CODE: dict[str, int] = {
 class MetadataModel(BaseModel):
     station: str
     product: str
-    scan_time: str  # ISO-8601 UTC
+    scan_time: datetime  # Pydantic serializes datetime → ISO-8601 with TZ on dump.
     elevation_deg: float
     vcp: int
     renderer_version: str
@@ -83,8 +84,6 @@ def build_app(config: Config | None = None) -> FastAPI:
             resp: RenderResponse = await asyncio.to_thread(svc.render, req)
         except ServiceError as exc:
             REQUESTS_TOTAL.labels(outcome=f"error_{exc.code}").inc()
-            if exc.code == "internal":
-                S3_ERRORS_TOTAL.inc()
             raise HTTPException(
                 status_code=_STATUS_FOR_CODE.get(exc.code, 500),
                 detail={"error": exc.code, "detail": exc.detail},
@@ -98,7 +97,7 @@ def build_app(config: Config | None = None) -> FastAPI:
             metadata=MetadataModel(
                 station=resp.metadata.station,
                 product=resp.metadata.product,
-                scan_time=resp.metadata.scan_time.isoformat(),
+                scan_time=resp.metadata.scan_time,  # datetime; Pydantic emits ISO-8601.
                 elevation_deg=resp.metadata.elevation_deg,
                 vcp=resp.metadata.vcp,
                 renderer_version=resp.metadata.renderer_version,

--- a/renderer/src/dras_renderer/decode.py
+++ b/renderer/src/dras_renderer/decode.py
@@ -39,6 +39,8 @@ def decode_level2_archive(volume_bytes: bytes) -> DecodedScan:
     """
     try:
         radar = pyart.io.read_nexrad_archive(io.BytesIO(volume_bytes))
+        # Py-ART sorts sweeps by ascending elevation, so index 0 is the
+        # lowest tilt — which is what the base-reflectivity render expects.
         return DecodedScan(
             radar=radar,
             station_id=_extract_station(radar),

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import io
 import math
-import os
 from dataclasses import dataclass
 
-# Headless backend MUST be selected before importing pyplot.  Use
-# matplotlib.use() (not just setdefault) so it wins even when the
-# macOS backend has already been detected by the env.
-os.environ["MPLBACKEND"] = "Agg"
+# Headless backend MUST be selected before importing pyplot. ``matplotlib.use``
+# is authoritative — it overrides the env-var-based detection that runs at
+# import time. No need to also set MPLBACKEND in the process env: ``use`` wins.
 import matplotlib
 
 matplotlib.use("Agg")
@@ -68,6 +66,7 @@ def render_base_reflectivity(scan: DecodedScan, opts: RenderOptions) -> bytes:
         ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
 
         display = pyart.graph.RadarMapDisplay(radar)
+        # sweep=0 == lowest tilt: Py-ART sorts sweeps by ascending elevation.
         display.plot_ppi_map(
             "reflectivity",
             sweep=0,

--- a/renderer/src/dras_renderer/s3.py
+++ b/renderer/src/dras_renderer/s3.py
@@ -109,17 +109,24 @@ class S3Client:
         with ThreadPoolExecutor(max_workers=self.list_workers) as executor:
             results = list(executor.map(chunks_for, VOLUME_SLOTS))
 
+        # ``sorted(keys)`` orders chunks by lex; chunk filenames are
+        # ``<YYYYMMDD-HHMMSS>-<NNN>-<TYPE>``, where the chunk-num field is
+        # zero-padded to 3 digits. Within a single volume's keys this makes
+        # lex order == chronological / chunk-num order. If NOAA ever drops
+        # the zero-pad, parse the chunk-num explicitly via ``int(name.rsplit("-", 2)[-2])``.
         non_empty = [(v, sorted(keys)) for v, keys in results if keys]
         if not non_empty:
             return None
 
-        # The volume with the largest "newest chunk filename" wins.
-        # Compare on the filename only (after last '/') so that slot numbers
-        # like 5 vs 17 don't distort the lex comparison — only the
-        # YYYYMMDD-HHMMSS prefix in the filename determines recency.
-        best_vol, best_chunks = max(non_empty, key=lambda item: item[1][-1].rsplit("/", 1)[-1])
-        latest_filename = best_chunks[-1].rsplit("/", 1)[-1]
-        ts_prefix = latest_filename[:15]  # "YYYYMMDD-HHMMSS"
+        # Compare slots only on the YYYYMMDD-HHMMSS prefix of the newest
+        # filename — defensive against future drift in the chunk-num/type
+        # suffix format (e.g. a per-tilt suffix change). The volume start
+        # timestamp is what determines recency.
+        def prefix_key(item: tuple[int, list[str]]) -> str:
+            return item[1][-1].rsplit("/", 1)[-1][:15]
+
+        best_vol, best_chunks = max(non_empty, key=prefix_key)
+        ts_prefix = prefix_key((best_vol, best_chunks))  # "YYYYMMDD-HHMMSS"
         # Slots are reused (volume IDs cycle 0-999). A slot mid-overwrite can hold
         # chunks from two distinct volumes; keep only the winning volume's chunks.
         volume_chunks = tuple(

--- a/renderer/src/dras_renderer/s3.py
+++ b/renderer/src/dras_renderer/s3.py
@@ -67,11 +67,15 @@ class S3Client:
         region: str,
         anonymous: bool = True,
         list_workers: int = 64,
+        download_workers: int | None = None,
         latest_volume_ttl: float = 30.0,
     ) -> None:
         self.bucket = bucket
         self.region = region
         self.list_workers = list_workers
+        # Default download concurrency to list_workers — the boto3 client's
+        # max_pool_connections=64 caps real parallelism regardless.
+        self.download_workers = download_workers if download_workers is not None else list_workers
         self.latest_volume_ttl = latest_volume_ttl
         self._client: Any = boto3.client(
             "s3", region_name=region, config=_make_config(anonymous)
@@ -131,23 +135,37 @@ class S3Client:
         )
 
     def download_volume(self, volume: LatestVolume) -> bytes:
-        """Fetch all chunks for ``volume`` and concatenate them in chunk-num order.
+        """Fetch all chunks for ``volume`` concurrently and concatenate them in chunk-num order.
 
         The result is a Level II Archive blob byte-identical to a ``_V06`` file:
         ``[AR2V volume header from chunk 1][LDM-record-framed bzip2 streams from
         every chunk]``. Py-ART's ``read_nexrad_archive`` handles the per-record
         bzip2 decompression itself; we must NOT decompress at this layer.
+
+        Concurrency: chunks are fetched in parallel via a ThreadPoolExecutor sized
+        to ``self.download_workers``; the caller-visible byte order matches
+        ``volume.chunk_keys`` (chunk-num order), independent of fetch completion
+        order.
         """
-        chunk_bodies: list[bytes] = []
-        for key in volume.chunk_keys:
+        def fetch_one(key: str) -> bytes:
             try:
                 resp = self._client.get_object(Bucket=self.bucket, Key=key)
             except ClientError as e:
                 code = e.response.get("Error", {}).get("Code", "")
                 raise S3Error(f"S3 get_object failed on {key}: {code}") from e
-            chunk_bodies.append(cast(bytes, resp["Body"].read()))
+            return cast(bytes, resp["Body"].read())
 
-        return b"".join(chunk_bodies)
+        if not volume.chunk_keys:
+            return b""
+
+        with ThreadPoolExecutor(max_workers=self.download_workers) as executor:
+            # executor.map preserves input order in its output, so the join below
+            # produces chunks in chunk-num (== input) order regardless of fetch
+            # completion order. ClientError raised inside fetch_one is wrapped in
+            # S3Error and propagated when its result is consumed below.
+            bodies = list(executor.map(fetch_one, volume.chunk_keys))
+
+        return b"".join(bodies)
 
     def _list_keys(self, prefix: str) -> list[str]:
         keys: list[str] = []

--- a/renderer/src/dras_renderer/service.py
+++ b/renderer/src/dras_renderer/service.py
@@ -10,6 +10,7 @@ from cachetools import LRUCache
 
 from dras_renderer.cache import RenderCache
 from dras_renderer.decode import DecodedScan, decode_level2_archive
+from dras_renderer.metrics import S3_ERRORS_TOTAL
 from dras_renderer.render import RenderOptions, render_base_reflectivity
 from dras_renderer.s3 import S3Client, S3Error
 from dras_renderer.version import VERSION
@@ -77,6 +78,7 @@ class RenderService:
             try:
                 volume = self._s3.latest_volume(req.station)
             except S3Error as exc:
+                S3_ERRORS_TOTAL.inc()
                 raise ServiceError("internal", f"S3 list failed: {exc}") from exc
             if volume is None:
                 raise ServiceError(
@@ -95,6 +97,7 @@ class RenderService:
             try:
                 volume_bytes = self._s3.download_volume(volume)
             except S3Error as exc:
+                S3_ERRORS_TOTAL.inc()
                 raise ServiceError("internal", f"S3 download failed: {exc}") from exc
 
             try:

--- a/renderer/tests/fixtures/README.md
+++ b/renderer/tests/fixtures/README.md
@@ -28,3 +28,30 @@ when replacing the fixture.
 - Final gzipped fixture size: 8,485,815 bytes (~8.1 MB)
 - VCP: 35
 - Lowest tilt elevation: ~0.483°
+
+## Design deviation: no `chunks/` subdirectory
+
+The original level2-renderer design (referenced in the comprehensive review
+of `feat/level2-renderer-service`, GitHub issue #85, M10) called for a small
+set of real bzip2-compressed chunks under `renderer/tests/fixtures/chunks/`
+to cover `S3Client.download_volume` end-to-end without network.
+
+The implementation instead uses:
+
+- **Synthetic moto bytes** in `tests/test_s3.py` to verify chunk ordering,
+  the AR2V/E suffix invariants, slot-overwrite filtering, and the parallel
+  download path. Faster than network fixtures and exercises the same code
+  paths.
+- **`KATX_test.ar2v.gz`** in this directory for the assembled-volume
+  byte-level decode/render path (`tests/test_decode.py`,
+  `tests/test_render.py`, `tests/test_service.py`).
+
+This is sufficient because `download_volume` is a pure parallel
+concatenation — its only contract is "fetch every chunk, join in chunk-num
+order" and the moto-backed tests cover both the happy path and the
+missing-chunk error path. Adding real bzip2-framed chunk fixtures would
+duplicate decode coverage already provided by the `_V06` archive fixture.
+
+If a future change makes `download_volume` non-trivial (e.g. partial-volume
+decoding before py-art, or streaming decompression at this layer), revisit
+this decision and add a `chunks/` fixture set.

--- a/renderer/tests/test_app_health.py
+++ b/renderer/tests/test_app_health.py
@@ -12,3 +12,41 @@ def test_healthz_returns_ok() -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert "renderer_version" in body
+
+
+def test_render_response_scan_time_is_iso8601() -> None:
+    """MetadataModel.scan_time is now `datetime`; JSON output must remain ISO-8601 with TZ."""
+    from datetime import UTC, datetime
+
+    from fastapi.testclient import TestClient
+
+    from dras_renderer.service import RenderMetadata, RenderResponse
+
+    fake_meta = RenderMetadata(
+        station="KATX",
+        product="base_reflectivity",
+        scan_time=datetime(2026, 4, 29, 12, 5, 0, tzinfo=UTC),
+        elevation_deg=0.5,
+        vcp=212,
+        renderer_version="test",
+    )
+    fake_resp = RenderResponse(png=b"\x89PNG\r\n\x1a\n", metadata=fake_meta)
+
+    class StubService:
+        def render(self, req):
+            return fake_resp
+
+    app = build_app()
+    app.state.service = StubService()
+
+    with TestClient(app) as tc:
+        r = tc.get("/render/KATX")
+    assert r.status_code == 200
+    body = r.json()
+    st = body["metadata"]["scan_time"]
+    # Pin the canonical wire format: Pydantic v2 emits UTC datetimes as
+    # "...Z" (RFC 3339). The previous code path used datetime.isoformat(),
+    # which emits "...+00:00"; both encode the same instant, but the wire
+    # format DID change with M12 — pin it so a future Pydantic regression
+    # back to "+00:00" is caught here, not by a downstream consumer.
+    assert st == "2026-04-29T12:05:00Z"

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -41,3 +41,18 @@ def test_render_respects_range_km(decoded: DecodedScan) -> None:
     img_a = Image.open(io.BytesIO(a))
     img_b = Image.open(io.BytesIO(b))
     assert img_a.size == img_b.size
+
+
+def test_matplotlib_uses_agg_backend() -> None:
+    """matplotlib.use('Agg') in render.py must select the Agg backend at import time.
+
+    This regression-locks the headless-backend selection across the M5 change
+    that drops the redundant ``os.environ["MPLBACKEND"] = "Agg"`` line — the
+    explicit ``matplotlib.use("Agg")`` call is authoritative.
+    """
+    import matplotlib
+
+    # Importing dras_renderer.render forces matplotlib.use('Agg') to execute.
+    import dras_renderer.render  # noqa: F401
+
+    assert matplotlib.get_backend().lower() == "agg"

--- a/renderer/tests/test_s3.py
+++ b/renderer/tests/test_s3.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime
 
 import boto3
 import pytest
-from botocore import UNSIGNED
 from moto import mock_aws
 
 from dras_renderer.s3 import (
@@ -104,11 +103,42 @@ def test_download_volume_raises_s3error_on_missing_chunk(mock_bucket: str) -> No
             client.download_volume(v)
 
 
-def test_anonymous_mode_uses_unsigned_config() -> None:
-    """When anonymous=True, the boto3 client is built with UNSIGNED."""
-    client = S3Client(bucket=BUCKET, region="us-east-1", anonymous=True)
-    cfg = client._client.meta.config
-    assert cfg.signature_version is UNSIGNED
+def test_anonymous_mode_uses_unsigned_requests() -> None:
+    """When anonymous=True, S3 requests must NOT carry an Authorization header.
+
+    This is a behavior-level check — it does not reach into private botocore
+    state. A regression that flipped the client to signed mode would be
+    caught here even if botocore's internal config layout changed.
+    """
+    captured: dict[str, dict[str, str]] = {}
+
+    def capture(**kwargs: object) -> None:
+        # botocore's `before-sign.s3` hook fires on every prepared request,
+        # including under moto. The request object exposes its headers as a
+        # case-insensitive mapping; coerce to plain dict for the assertion.
+        request = kwargs.get("request")
+        if request is not None:
+            captured["headers"] = dict(request.headers)  # type: ignore[attr-defined]
+
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=BUCKET)
+
+        client = S3Client(bucket=BUCKET, region="us-east-1", anonymous=True)
+        client._client.meta.events.register("before-sign.s3", capture)
+
+        # latest_volume issues paginated LIST calls; we don't care about the
+        # result (the bucket is empty), only that a real signed/unsigned LIST
+        # is dispatched so the before-sign hook captures its headers.
+        client.latest_volume("KATX")
+
+    headers = captured.get("headers")
+    assert headers is not None, "no request was captured by the before-sign.s3 hook"
+    # Header keys are case-insensitive in HTTP; normalize for the membership check.
+    lowered = {k.lower() for k in headers}
+    assert "authorization" not in lowered, (
+        f"anonymous client must not sign requests; got headers: {headers}"
+    )
 
 
 def test_volume_not_found_error_subclasses_s3_error() -> None:

--- a/renderer/tests/test_s3.py
+++ b/renderer/tests/test_s3.py
@@ -142,3 +142,29 @@ def test_latest_volume_filters_chunks_to_winning_timestamp() -> None:
         # download_volume must produce only the new volume's payloads, concatenated as-is.
         body = client.download_volume(v)
         assert body == b"new-S" + b"new-I" + b"new-E"
+
+
+def test_download_volume_concatenates_in_chunk_keys_order() -> None:
+    """Output bytes must be in chunk_keys order regardless of fetch completion order.
+
+    This is the correctness invariant of the parallel download path: a refactor
+    to ``as_completed`` (which yields by completion order) would break it.
+    """
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=BUCKET)
+        # 8 chunks with bodies that encode their chunk-num so order is verifiable.
+        for n in range(1, 9):
+            _put_chunk(s3, f"KATX/3/20260429-130000-00{n}-I", f"chunk-{n:02d}".encode())
+        client = S3Client(
+            bucket=BUCKET,
+            region="us-east-1",
+            anonymous=False,
+            list_workers=4,
+            download_workers=8,
+            latest_volume_ttl=0.0,
+        )
+        v = client.latest_volume("KATX")
+        assert v is not None
+        body = client.download_volume(v)
+        assert body == b"".join(f"chunk-{n:02d}".encode() for n in range(1, 9))

--- a/renderer/tests/test_s3.py
+++ b/renderer/tests/test_s3.py
@@ -144,6 +144,36 @@ def test_latest_volume_filters_chunks_to_winning_timestamp() -> None:
         assert body == b"new-S" + b"new-I" + b"new-E"
 
 
+def test_latest_volume_with_tied_prefixes_returns_a_valid_slot() -> None:
+    """Tie case: when two slots share the YYYYMMDD-HHMMSS prefix of their
+    newest chunk, the picker must return one of them deterministically and
+    return only that slot's chunks.
+
+    For well-formed NEXRAD filenames the prefix-only and full-filename
+    comparisons agree whenever timestamps differ (the prefix is the
+    leftmost varying field, so it dominates lex order). The two algorithms
+    can only disagree when prefixes tie — and even then, either slot is
+    a valid answer. This test pins the post-condition: the returned
+    chunk_keys belong to a single, real slot.
+    """
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=BUCKET)
+        # Same timestamp prefix; suffix differs across slots.
+        _put_chunk(s3, "KATX/5/20260429-120000-001-S", b"a")
+        _put_chunk(s3, "KATX/5/20260429-120000-002-I", b"b")
+        _put_chunk(s3, "KATX/5/20260429-120000-003-E", b"c")
+        _put_chunk(s3, "KATX/17/20260429-120000-001-S", b"x")
+        _put_chunk(s3, "KATX/17/20260429-120000-002-I", b"y")
+
+        client = _make_client()
+        v = client.latest_volume("KATX")
+        assert v is not None
+        assert v.volume_number in {5, 17}
+        assert all(k.startswith(f"KATX/{v.volume_number}/20260429-120000-") for k in v.chunk_keys)
+        assert v.latest_chunk_time == datetime(2026, 4, 29, 12, 0, 0, tzinfo=UTC)
+
+
 def test_download_volume_concatenates_in_chunk_keys_order() -> None:
     """Output bytes must be in chunk_keys order regardless of fetch completion order.
 

--- a/renderer/tests/test_service.py
+++ b/renderer/tests/test_service.py
@@ -90,3 +90,37 @@ def test_unsupported_product_raises() -> None:
         svc.render(RenderRequest(station="KATX", product="velocity"))
     assert excinfo.value.code == "unsupported_product"
     s3.latest_volume.assert_not_called()
+
+
+def test_render_increments_s3_errors_on_list_failure() -> None:
+    """An S3Error from latest_volume must increment renderer_s3_errors_total."""
+    from dras_renderer.metrics import S3_ERRORS_TOTAL
+
+    s3 = MagicMock()
+    s3.latest_volume.side_effect = S3Error("simulated list failure")
+    svc = RenderService(s3=s3, cache=RenderCache(max_size=8))
+
+    before = S3_ERRORS_TOTAL._value.get()  # type: ignore[attr-defined]
+    with pytest.raises(ServiceError) as excinfo:
+        svc.render(RenderRequest(station="KATX"))
+    assert excinfo.value.code == "internal"
+    after = S3_ERRORS_TOTAL._value.get()  # type: ignore[attr-defined]
+    assert after == before + 1
+    s3.download_volume.assert_not_called()
+
+
+def test_render_increments_s3_errors_on_download_failure() -> None:
+    """An S3Error from download_volume must also increment renderer_s3_errors_total."""
+    from dras_renderer.metrics import S3_ERRORS_TOTAL
+
+    s3 = MagicMock()
+    s3.latest_volume.return_value = _vol()
+    s3.download_volume.side_effect = S3Error("simulated download failure")
+    svc = RenderService(s3=s3, cache=RenderCache(max_size=8))
+
+    before = S3_ERRORS_TOTAL._value.get()  # type: ignore[attr-defined]
+    with pytest.raises(ServiceError) as excinfo:
+        svc.render(RenderRequest(station="KATX"))
+    assert excinfo.value.code == "internal"
+    after = S3_ERRORS_TOTAL._value.get()  # type: ignore[attr-defined]
+    assert after == before + 1


### PR DESCRIPTION
## Summary

Resolves the deferred Minor (and one Important) items from the comprehensive review of `feat/level2-renderer-service` ([issue #85](https://github.com/jacaudi/dras/issues/85)).

- **I5** (headline): parallelize chunk downloads in `S3Client.download_volume` via `ThreadPoolExecutor.map`. Saves 3–4 s of serial RTT latency on uncached `/render` (~67 chunks per volume). `executor.map` preserves input order so the assembled byte stream stays in chunk-num order — required because chunk 1 carries the AR2V header.
- **M2 + M12**: move `S3_ERRORS_TOTAL.inc()` from `app.py` to `service.py` at the actual S3 error sites (cleaner attribution, removes the `if exc.code == "internal"` heuristic). Type `MetadataModel.scan_time` as `datetime` instead of `str` and drop `.isoformat()` at envelope construction.
- **M3 + M11**: comment the chunk-num lex-sort assumption in `s3.py`; compare slot freshness on the `YYYYMMDD-HHMMSS` 15-char prefix only (defensive against future suffix-format drift).
- **M4 + M5**: document that `radar.fixed_angle["data"][0]` and `sweep=0` are the lowest tilt; drop the redundant `os.environ["MPLBACKEND"] = "Agg"` line in `render.py` (`matplotlib.use("Agg")` is authoritative).
- **M6 + M7**: comment the two-stage `uv sync` layer-cache rationale in the `renderer/Dockerfile`; add a build-time smoke test that runs as the renderer UID and fails the build if the Cartopy cache copy is empty/unreachable. Local build verified: 294 states, 1428 coastline features.
- **M8**: plumb `context.Context` through `image.Source.Fetch` so cancellation propagates from `Monitor.Start`'s ticker through to the HTTP round-trip. Drops the `context.Background()` fallback in `renderer.Client.Fetch`.
- **M9**: replace the private-state assertion in `test_anonymous_mode_uses_unsigned_config` with a behavior-level header check via a `before-sign.s3` botocore hook. Robust to internal botocore config refactors.
- **M10**: document the deviation from the design's `tests/fixtures/chunks/` directory in `renderer/tests/fixtures/README.md` — synthetic moto bytes + the assembled-volume `.ar2v.gz` fixture cover the same paths.

## API wire-format note

`MetadataModel.scan_time` is now serialized as RFC 3339 with a `Z` suffix (e.g. `2026-04-29T12:05:00Z`) instead of the previous `+00:00` offset (the old code path called `datetime.isoformat()`). Both encode the same instant; clients parsing with a real ISO-8601 parser are unaffected. The renderer's only consumer today is `dras/internal/renderer/client.go`, which doesn't parse `scan_time`. `test_render_response_scan_time_is_iso8601` pins the new wire format.

## Test plan

- [x] `cd renderer && uv run pytest -v` → 36 passed (was 32 + 4 new regression-locking tests).
- [x] `cd renderer && uv run ruff check src tests` → clean.
- [x] `cd renderer && uv run mypy src` → clean.
- [x] `cd dras && go test ./...` → all 9 packages pass (1 new ctx-cancellation test in `renderer/client_test.go`).
- [x] `cd dras && go vet ./...` → clean.
- [x] `cd dras && gofmt -l .` → empty.
- [x] `docker build` of `renderer/` succeeds end-to-end with the new build-time cartopy smoke test (`cartopy cache verified: 294 states, 1428 coastline features`).

Closes #85.