### PR TITLE
fix(docs): update README badges; route renderer Python lint through component-lint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,8 +28,18 @@ jobs:
       coverage: true
       working-directory: dras
 
+  # Python ruff via the central reusable lint workflow (mirrors the Go lint setup).
+  lint-renderer-ruff:
+    name: Lint Renderer (Ruff)
+    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
+    with:
+      python: true
+      working-directory: renderer
+      ruff-args: src tests
+
+  # Type-checking still uses uv since component-lint doesn't cover mypy.
   lint-renderer:
-    name: Lint Renderer
+    name: Lint Renderer (Mypy)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,8 +51,6 @@ jobs:
           version: "0.5.x"
       - name: Sync deps
         run: uv sync --frozen
-      - name: Ruff
-        run: uv run ruff check src tests
       - name: Mypy
         run: uv run mypy src
 
@@ -111,7 +119,7 @@ jobs:
 
   container-renderer-amd64:
     name: Build Renderer Container (amd64)
-    needs: [lint-renderer, test-renderer]
+    needs: [lint-renderer, lint-renderer-ruff, test-renderer]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -134,7 +142,7 @@ jobs:
 
   container-renderer-arm64:
     name: Build Renderer Container (arm64)
-    needs: [lint-renderer, test-renderer]
+    needs: [lint-renderer, lint-renderer-ruff, test-renderer]
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![On Merge](https://github.com/jacaudi/dras/actions/workflows/on-merge.yml/badge.svg)](https://github.com/jacaudi/dras/actions/workflows/on-merge.yml) [![Versioned Release](https://github.com/jacaudi/dras/actions/workflows/on-release.yml/badge.svg)](https://github.com/jacaudi/dras/actions/workflows/on-release.yml)
+[![CI/CD](https://github.com/jacaudi/dras/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/jacaudi/dras/actions/workflows/ci-cd.yml) [![PR Validation](https://github.com/jacaudi/dras/actions/workflows/pr.yml/badge.svg)](https://github.com/jacaudi/dras/actions/workflows/pr.yml) [![Latest Release](https://img.shields.io/github/v/release/jacaudi/dras?logo=github)](https://github.com/jacaudi/dras/releases/latest) [![License](https://img.shields.io/github/license/jacaudi/dras)](LICENSE)
 
 # DRAS — Doppler Radar Alerting Service
 


### PR DESCRIPTION
## Summary

Two cleanups on the dras repo:

### 1. README badges

The top-of-file badges still pointed at `on-merge.yml` and `on-release.yml` — both removed during the 2026-04-25 CI restructure (consolidated to `ci-cd.yml` + `pr.yml`). They've been rendering broken since then.

Replaces with four current badges:
- **CI/CD** (`ci-cd.yml`) — push-to-main pipeline (lint → test → release → containers → helm-publish).
- **PR Validation** (`pr.yml`) — PR pipeline (lint, test, no-push container builds, helm-validate).
- **Latest Release** — shields.io GitHub release badge.
- **License** — shields.io license badge.

### 2. Renderer Python lint via central component

The renderer's Ruff check is now routed through `jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1` with `python: true`, mirroring the Go and YAML lint setup for the dras service. The bespoke `lint-renderer` job is trimmed to mypy-only since the central component does not cover type checking.

`container-renderer-{amd64,arm64}` now also require `lint-renderer-ruff` so a Ruff regression blocks the renderer container build the same way a Mypy or Pytest failure does.

## Test plan

- [ ] Render the README on github.com and confirm all four badges load.
- [ ] PR CI: `Lint Renderer (Ruff)` (component-lint) is green; `Lint Renderer (Mypy)` (bespoke uv + mypy) is green.
- [ ] PR CI: renderer container builds wait on both renderer lint jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)