### PR TITLE
ci: per-language path filters, dras cross-compile, PR concurrency cancel

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   lint:
-    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.2
     permissions:
       contents: read
     with:
@@ -31,7 +31,7 @@ jobs:
     secrets: inherit
 
   test:
-    uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.2
     permissions:
       contents: read
     with:
@@ -43,7 +43,7 @@ jobs:
   release:
     needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: jacaudi/github-actions/.github/workflows/component-semantic-release.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-semantic-release.yml@v0.20.2
     permissions:
       contents: write
       issues: write
@@ -81,7 +81,7 @@ jobs:
   container-dras:
     needs: [release, version-parts]
     if: needs.release.outputs.new-release-published == 'true'
-    uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.2
     permissions:
       contents: read
       packages: write
@@ -108,7 +108,7 @@ jobs:
   container-renderer:
     needs: [release, version-parts]
     if: needs.release.outputs.new-release-published == 'true'
-    uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.2
     permissions:
       contents: read
       packages: write
@@ -136,7 +136,7 @@ jobs:
   helm-publish:
     needs: [release, version-parts]
     if: needs.release.outputs.new-release-published == 'true'
-    uses: jacaudi/github-actions/.github/workflows/component-helm-publish.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-helm-publish.yml@v0.20.2
     permissions:
       contents: read
       packages: write
@@ -147,5 +147,5 @@ jobs:
   pipeline-summary:
     if: always()
     needs: [lint, test, release, container-dras, container-renderer, helm-publish]
-    uses: jacaudi/github-actions/.github/workflows/component-pipeline-summary.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-pipeline-summary.yml@v0.20.2
     secrets: inherit

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -92,6 +92,11 @@ jobs:
       file: dras/Dockerfile
       platforms: linux/amd64,linux/arm64
       push: true
+      # dras is a static Go binary; the Dockerfile cross-compiles via
+      # GOOS/GOARCH, so the arm64 build doesn't need a native arm runner
+      # (no QEMU emulation runs at the Go layer either). Forcing the
+      # arm64 build to amd64 saves ~20s of arm-runner provisioning.
+      arm64-runner: ubuntu-24.04
       version: ${{ needs.release.outputs.new-release-version-v }}
       tags: |
         ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
     name: Lint Code
     needs: changes
     if: needs.changes.outputs.dras == 'true' || needs.changes.outputs.yaml == 'true'
-    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.2
     with:
       yaml: true
       go: true
@@ -61,7 +61,7 @@ jobs:
     name: Run Tests
     needs: changes
     if: needs.changes.outputs.dras == 'true'
-    uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.2
     with:
       test-framework: go
       coverage: true
@@ -72,7 +72,7 @@ jobs:
     name: Lint Renderer (Ruff)
     needs: changes
     if: needs.changes.outputs.renderer == 'true'
-    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.2
     with:
       python: true
       working-directory: renderer

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 ---
 # Pull Request Validation
-# Fast feedback on PRs: lint, test, and no-push container builds
+# Fast feedback on PRs: lint, test, helm validation
 name: PR Validation
 
 "on":
@@ -11,9 +11,46 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancel in-progress runs when a PR is force-pushed or new commits land.
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
+  # Single paths-filter pass; downstream jobs `if:` on its outputs so an
+  # untouched language doesn't pay the runner-spinup cost.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      dras: ${{ steps.filter.outputs.dras }}
+      renderer: ${{ steps.filter.outputs.renderer }}
+      chart: ${{ steps.filter.outputs.chart }}
+      yaml: ${{ steps.filter.outputs.yaml }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            dras:
+              - 'dras/**'
+              - 'go.mod'
+              - 'go.sum'
+            renderer:
+              - 'renderer/**'
+            chart:
+              - 'chart/**'
+              - 'scripts/sync-chart-version*.sh'
+              - '.releaserc.json'
+            yaml:
+              - '**/*.yml'
+              - '**/*.yaml'
+
   lint:
     name: Lint Code
+    needs: changes
+    if: needs.changes.outputs.dras == 'true' || needs.changes.outputs.yaml == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
     with:
       yaml: true
@@ -22,6 +59,8 @@ jobs:
 
   test:
     name: Run Tests
+    needs: changes
+    if: needs.changes.outputs.dras == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.1
     with:
       test-framework: go
@@ -31,6 +70,8 @@ jobs:
   # Python ruff via the central reusable lint workflow (mirrors the Go lint setup).
   lint-renderer-ruff:
     name: Lint Renderer (Ruff)
+    needs: changes
+    if: needs.changes.outputs.renderer == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
     with:
       python: true
@@ -40,6 +81,8 @@ jobs:
   # Type-checking still uses uv since component-lint doesn't cover mypy.
   lint-renderer:
     name: Lint Renderer (Mypy)
+    needs: changes
+    if: needs.changes.outputs.renderer == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -56,6 +99,8 @@ jobs:
 
   test-renderer:
     name: Test Renderer
+    needs: changes
+    if: needs.changes.outputs.renderer == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -72,62 +117,45 @@ jobs:
 
   helm-validate:
     name: Validate Helm Chart
+    needs: changes
+    if: needs.changes.outputs.chart == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Detect chart changes
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            chart:
-              - 'chart/**'
-              - 'scripts/sync-chart-version*.sh'
-              - '.releaserc.json'
-
       - name: Set up Helm
-        if: steps.changes.outputs.chart == 'true'
         uses: azure/setup-helm@v4
         with:
           version: v3.16.4
 
       - name: Install helm-unittest plugin
-        if: steps.changes.outputs.chart == 'true'
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
 
       - name: Install kubeconform
-        if: steps.changes.outputs.chart == 'true'
         run: |
           curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
             | sudo tar xz -C /usr/local/bin kubeconform
           kubeconform -v
 
       - name: Helm dependency update
-        if: steps.changes.outputs.chart == 'true'
         run: helm dependency update chart/
 
       - name: Helm lint (strict)
-        if: steps.changes.outputs.chart == 'true'
         run: helm lint chart/ --strict
 
       - name: helm-unittest
-        if: steps.changes.outputs.chart == 'true'
         run: helm unittest chart/
 
       - name: Helm template — standard mode | kubeconform
-        if: steps.changes.outputs.chart == 'true'
         run: |
           helm template dras chart/ -f chart/tests/values-standard.yaml --namespace monitoring \
             | kubeconform -strict -summary -kubernetes-version 1.30.0
 
       - name: Helm template — advanced mode | kubeconform
-        if: steps.changes.outputs.chart == 'true'
         run: |
           helm template dras chart/ -f chart/tests/values-advanced.yaml --namespace monitoring \
             | kubeconform -strict -summary -kubernetes-version 1.30.0
 
       - name: sync-chart-version.sh self-test
-        if: steps.changes.outputs.chart == 'true'
         run: bash scripts/sync-chart-version_test.sh


### PR DESCRIPTION
## Summary

Three small CI cleanups bundled into one PR. Wins from the brainstorm; the bigger play (`component-quality.yml`) is captured upstream as [jacaudi/github-actions#91](https://github.com/jacaudi/github-actions/issues/91), and the digest-artifact namespace fix is upstream as [jacaudi/github-actions#90](https://github.com/jacaudi/github-actions/pull/90).

### 1. Per-language path filters (`pr.yml`) — saves PR CI time

A new `changes` job runs `dorny/paths-filter@v3` once and exposes per-language outputs:

| filter | matches |
|---|---|
| `dras` | `dras/**`, `go.mod`, `go.sum` |
| `renderer` | `renderer/**` |
| `chart` | `chart/**`, `scripts/sync-chart-version*.sh`, `.releaserc.json` |
| `yaml` | `**/*.yml`, `**/*.yaml` |

Each downstream lint/test job gates on `needs.changes.outputs.<filter>` so a chart-only PR (like #99) skips Go lint, Go test, and all renderer Python jobs entirely. A docs-only PR skips everything except yaml lint (only fires if a YAML file changed).

`helm-validate`'s inline paths-filter is removed since the workflow-level `changes` job covers it; the per-step `if:` guards inside the helm job are also removed (the job either runs all its steps or doesn't run at all).

**Expected save**: 30–90s on PRs that don't touch all surfaces.

### 2. Cross-compile dras instead of native arm64 (`ci-cd.yml`)

`container-dras` now passes `arm64-runner: ubuntu-24.04`, building both arches on amd64 runners. dras' Dockerfile already cross-compiles via `GOOS=$TARGETOS GOARCH=$TARGETARCH` with `CGO_ENABLED=0` (static binary), so QEMU never runs at the Go layer — it's free cross-compilation.

`container-renderer` is left on the native arm runner because Py-ART / numpy C extensions benefit from native compilation; QEMU emulation there would slow things down dramatically.

**Expected save**: ~20s per release on the dras image (no arm-runner provisioning wait).

### 3. PR concurrency cancel (`pr.yml`)

Adds:

```yaml
concurrency:
  group: pr-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

Force-push or new commit on a PR cancels the in-flight run instead of letting it finish before the new one starts.

## Out of scope (tracked elsewhere)

- **A** — `component-quality.yml` to combine lint+test in one runner: [jacaudi/github-actions#91](https://github.com/jacaudi/github-actions/issues/91). Bigger upstream change; saves another 50–75s on PR CI when shipped.
- **E2** — namespace digest artifacts: [jacaudi/github-actions#90](https://github.com/jacaudi/github-actions/pull/90). Fixes the v2.7.1 multi-arch manifest bug; merge that, cut a release, then bump dras' workflow refs in a follow-up.

## Test plan

- [ ] PR CI runs the `changes` job, then only the relevant gated jobs.
- [ ] A force-push to this branch cancels the prior in-flight run (concurrency).
- [ ] Verify YAML parses (locally: `yq '.' .github/workflows/{pr,ci-cd}.yml`).
- [ ] After merge, next release builds the dras arm64 image on an amd64 runner and produces a working multi-arch manifest (the renderer's still hits jacaudi/github-actions#90 — wait for that fix before relying on the renderer release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)