### PR TITLE
fix(chart,dras): renderer crash loop and upstream-fetch resilience

### DIFF
--- a/chart/templates/_app-template-values.tpl
+++ b/chart/templates/_app-template-values.tpl
@@ -52,10 +52,19 @@ sprig set/unset/dig operate reliably on all nested keys.
         "pullPolicy" $rendImg.pullPolicy) -}}
 {{- end -}}
 
-{{- /* Strip renderer pieces in standard mode */ -}}
+{{- /* Strip renderer pieces in standard mode. Includes any persistence
+     entries' advancedMounts targeting `renderer`, since bjw-s common
+     fails the render with "No enabled controller found with this
+     identifier" when an advancedMounts key references a stripped
+     controller. */ -}}
 {{- if eq .Values.mode "standard" -}}
   {{- $_ := unset $v.controllers "renderer" -}}
   {{- $_ := unset $v.service "renderer" -}}
+  {{- range $persistName, $persist := $v.persistence -}}
+    {{- if $persist.advancedMounts -}}
+      {{- $_ := unset $persist.advancedMounts "renderer" -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- /* Append Pushover envFrom on dras */ -}}
@@ -106,7 +115,18 @@ sprig set/unset/dig operate reliably on all nested keys.
 
   {{- /* renderer: S3_BUCKET, AWS_REGION envs */ -}}
   {{- $rendContainer := $v.controllers.renderer.containers.app -}}
-  {{- $rendEnv := default (list) $rendContainer.env -}}
+  {{- /* Mirror the dras-side env normalization so an operator can supply
+       `env:` as either a map ({FOO: bar}) or a list ([{name: FOO, value: bar}]).
+       Without this, append errors with `Cannot push on type map`. */ -}}
+  {{- $rendExisting := $rendContainer.env -}}
+  {{- $rendEnv := list -}}
+  {{- if kindIs "map" $rendExisting -}}
+    {{- range $k, $val := $rendExisting -}}
+      {{- $rendEnv = append $rendEnv (dict "name" $k "value" $val) -}}
+    {{- end -}}
+  {{- else if $rendExisting -}}
+    {{- $rendEnv = $rendExisting -}}
+  {{- end -}}
   {{- $rendEnv = append $rendEnv (dict "name" "S3_BUCKET" "value" .Values.renderer.s3.bucket) -}}
   {{- $rendEnv = append $rendEnv (dict "name" "AWS_REGION" "value" .Values.renderer.s3.region) -}}
   {{- $_ := set $rendContainer "env" $rendEnv -}}

--- a/chart/tests/mode_advanced_test.yaml
+++ b/chart/tests/mode_advanced_test.yaml
@@ -59,3 +59,43 @@ tests:
       - equal:
           path: spec.ports[0].port
           value: 8080
+
+  - it: dras pod mounts /tmp from a pod-scoped emptyDir at subPath dras
+    documentSelector:
+      path: metadata.name
+      value: dras
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /tmp
+            name: tmp
+            subPath: dras
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 256Mi
+
+  - it: renderer pod mounts /tmp from a pod-scoped emptyDir at subPath renderer
+    documentSelector:
+      path: metadata.labels["app.kubernetes.io/controller"]
+      value: renderer
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /tmp
+            name: tmp
+            subPath: renderer
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 256Mi

--- a/chart/tests/mode_standard_test.yaml
+++ b/chart/tests/mode_standard_test.yaml
@@ -48,3 +48,20 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: RENDERER_URL
+
+  - it: standard mode dras pod mounts /tmp from emptyDir at subPath dras
+    asserts:
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /tmp
+            name: tmp
+            subPath: dras
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 256Mi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,14 +67,42 @@ controllers:
   renderer:
     # Stripped before app-template sees values when mode == standard.
     replicas: 1
+    # The renderer image creates a `renderer` user (UID 10001) and installs
+    # the warmed Cartopy Natural Earth shapefile cache at
+    # /home/renderer/.local/share/cartopy at build time. The chart's
+    # defaultPodOptions runs as UID 65532 ("nobody"), which can't read that
+    # path — every render then re-downloads the shapefiles or falls back
+    # to a non-cached path. Override to UID 10001 here so the cache is
+    # actually used. Issue #103.
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
     containers:
       app:
         ports:
           - name: http
             containerPort: 8080
+        # Belt-and-suspenders: matplotlib defaults its config dir to
+        # ~/.config/matplotlib. With HOME=/ (no /etc/passwd entry for
+        # the runtime UID), it tries to mkdir /.config and fails. Pinning
+        # MPLCONFIGDIR to a writable tmpfs path silences the warning and
+        # avoids the auto-fallback's per-startup recompute.
+        env:
+          - name: MPLCONFIGDIR
+            value: /tmp/matplotlib
         resources:
-          requests: { cpu: 100m, memory: 384Mi }
-          limits:   { memory: 768Mi }
+          # Bumped to 1.5Gi limit on 2026-05-02 after issue #103. The prior
+          # 768Mi limit OOMKilled (exit 137) on busy stations like KATX
+          # whose Level II volumes peak Py-ART memory >800Mi. Profiled at
+          # ~1.1Gi peak during a render of KATX's largest recent volume;
+          # 1.5Gi gives ~30% headroom.
+          requests: { cpu: 100m, memory: 512Mi }
+          limits:   { memory: 1536Mi }
         probes:
           liveness:
             enabled: true
@@ -106,13 +134,51 @@ service:
         port: 8080
         protocol: HTTP
 
+# ── Volumes ──────────────────────────────────────────────────────────────
+persistence:
+  # Writable /tmp for both controllers. One emptyDir, two subPath mounts —
+  # each container sees its own isolated /tmp under a different subdir of
+  # the shared volume.
+  #
+  # Why per-container isolation: matplotlib stores its font/config cache
+  # at MPLCONFIGDIR=/tmp/matplotlib and Py-ART / Cartopy create transient
+  # files during a render. dras has no /tmp churn today but a future
+  # change could; subPaths keep the two containers' tmp namespaces from
+  # ever stepping on each other.
+  #
+  # Why one emptyDir instead of two: a single volume with sizeLimit
+  # caps total /tmp usage across the pod (matters for ephemeral-storage
+  # accounting on the node).
+  #
+  # Why mount /tmp at all: with pod-level `runAsNonRoot: true` and (today)
+  # a writable image rootfs, /tmp works without this mount — but it
+  # breaks the moment anyone hardens the pod with
+  # `readOnlyRootFilesystem: true`. Mounting an emptyDir here makes the
+  # cache lifecycle explicit (cleared on pod restart) and keeps the
+  # rootfs read-only-ready.
+  #
+  # Disk-backed by default. Set `medium: Memory` to switch to a tmpfs
+  # at the cost of subtracting from the pod's memory budget.
+  tmp:
+    enabled: true
+    type: emptyDir
+    sizeLimit: 256Mi
+    advancedMounts:
+      dras:
+        app:
+          - path: /tmp
+            subPath: dras
+      renderer:
+        app:
+          - path: /tmp
+            subPath: renderer
+
 # ── app-template required top-level stubs ────────────────────────────────
 # app-template/common iterates these keys directly; they must be present as
 # empty maps (not nil) so that range/get operations do not dereference nil.
 configMaps: {}
 ingress: {}
 networkpolicies: {}
-persistence: {}
 rawResources: {}
 rbac: {}
 route: {}

--- a/dras/internal/httpretry/transport.go
+++ b/dras/internal/httpretry/transport.go
@@ -1,0 +1,194 @@
+// Package httpretry provides an http.RoundTripper that retries transient
+// failures (network errors, 5xx, 408, 429) with exponential backoff and
+// jitter. It is used by both the renderer client and the legacy NWS radar
+// image client to absorb upstream flakiness — connection refused on a
+// cold-starting renderer, transient 5xx from NWS ridge, EOF from a renderer
+// worker that hit OOM mid-request, etc.
+//
+// All requests dras makes to upstream services are GETs; retrying GETs is
+// always safe.
+package httpretry
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jacaudi/dras/internal/logger"
+)
+
+// Transport wraps a base http.RoundTripper with bounded retry-with-backoff
+// for transient failures. Retries are GET-safe (network error, 5xx, 408,
+// 429). Non-transient failures (4xx other than 408/429) and successes are
+// returned immediately.
+type Transport struct {
+	// Base is the underlying transport. Defaults to http.DefaultTransport.
+	Base http.RoundTripper
+
+	// MaxAttempts is the total request count including the first try. A
+	// value <= 1 disables retries. Defaults to 4 (1 initial + 3 retries).
+	MaxAttempts int
+
+	// InitialBackoff is the wait before the first retry. Subsequent retries
+	// double the wait up to MaxBackoff. Defaults to 1s.
+	InitialBackoff time.Duration
+
+	// MaxBackoff caps the per-retry wait. Defaults to 30s.
+	MaxBackoff time.Duration
+}
+
+// DefaultTransport returns a Transport with the documented defaults.
+func DefaultTransport() *Transport {
+	return &Transport{
+		Base:           http.DefaultTransport,
+		MaxAttempts:    4,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+}
+
+// RoundTrip executes req with retry-on-transient-failure. The request body
+// is buffered up front so it can be replayed on each attempt. Context
+// cancellation aborts the retry loop immediately.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	maxAttempts := t.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	initial := t.InitialBackoff
+	if initial <= 0 {
+		initial = 1 * time.Second
+	}
+	maxBackoff := t.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = 30 * time.Second
+	}
+
+	// Buffer the body so we can reset it on each attempt.
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var (
+		resp    *http.Response
+		lastErr error
+	)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		// Restore body for this attempt.
+		if bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		resp, lastErr = base.RoundTrip(req)
+
+		if !shouldRetry(resp, lastErr) {
+			return resp, lastErr
+		}
+		if attempt >= maxAttempts {
+			return resp, lastErr
+		}
+
+		// Compute wait before next attempt; honor Retry-After if present.
+		wait := backoffFor(attempt, initial, maxBackoff, resp)
+
+		// Log the upcoming retry. Best-effort — never block on logger.
+		fields := map[string]string{
+			"attempt":      strconv.Itoa(attempt),
+			"max_attempts": strconv.Itoa(maxAttempts),
+			"wait_ms":      strconv.FormatInt(wait.Milliseconds(), 10),
+			"url":          req.URL.String(),
+		}
+		if lastErr != nil {
+			fields["err"] = lastErr.Error()
+		}
+		if resp != nil {
+			fields["status"] = strconv.Itoa(resp.StatusCode)
+		}
+		logger.WithFields(fields).Debug("retrying transient HTTP failure")
+
+		// Drain and close any previous response body so the connection
+		// can be reused.
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			resp = nil
+		}
+
+		// Wait, respecting context cancellation.
+		timer := time.NewTimer(wait)
+		select {
+		case <-timer.C:
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, req.Context().Err()
+		}
+	}
+
+	return resp, lastErr
+}
+
+// shouldRetry returns true if the (resp, err) pair represents a transient
+// failure worth retrying.
+func shouldRetry(resp *http.Response, err error) bool {
+	if err != nil {
+		// Network errors (connection refused, EOF, DNS failure, timeout
+		// at the transport layer) all surface as non-nil err. Context
+		// cancellation also lands here — but the caller's context check
+		// inside the retry loop handles it before we hit this path.
+		return !errors.Is(err, http.ErrSchemeMismatch)
+	}
+	if resp == nil {
+		return false
+	}
+	switch resp.StatusCode {
+	case http.StatusRequestTimeout, // 408
+		http.StatusTooManyRequests,     // 429
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout:      // 504
+		return true
+	}
+	return false
+}
+
+// backoffFor returns the wait duration before retry attempt+1. Honors a
+// Retry-After response header (in seconds) when present. Otherwise uses
+// exponential backoff with full jitter capped at maxBackoff.
+func backoffFor(attempt int, initial, maxBackoff time.Duration, resp *http.Response) time.Duration {
+	if resp != nil {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil && secs >= 0 {
+				wait := time.Duration(secs) * time.Second
+				if wait > maxBackoff {
+					wait = maxBackoff
+				}
+				return wait
+			}
+		}
+	}
+	// Exponential: initial, 2*initial, 4*initial, ... capped at max.
+	d := initial << (attempt - 1)
+	if d <= 0 || d > maxBackoff {
+		d = maxBackoff
+	}
+	// Full-jitter (AWS-style): pick uniform in [0, d). This avoids the
+	// thundering-herd pattern where every client retries at exactly the
+	// same multiple of the backoff base.
+	jitterNs := rand.Int64N(int64(d))
+	return time.Duration(jitterNs)
+}

--- a/dras/internal/httpretry/transport_test.go
+++ b/dras/internal/httpretry/transport_test.go
@@ -1,0 +1,249 @@
+package httpretry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeTransport is a stub RoundTripper that returns a scripted sequence of
+// (resp, err) pairs.
+type fakeTransport struct {
+	calls    atomic.Int32
+	scripted []roundTripResult
+}
+
+type roundTripResult struct {
+	statusCode int
+	body       string
+	err        error
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := int(f.calls.Add(1)) - 1
+	if idx >= len(f.scripted) {
+		// Out of script: fail loudly so test sees the unexpected call.
+		return nil, errors.New("fakeTransport: more calls than scripted")
+	}
+	r := f.scripted[idx]
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &http.Response{
+		StatusCode: r.statusCode,
+		Body:       io.NopCloser(strings.NewReader(r.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func newRequest(t *testing.T, ctx context.Context) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.test/x", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	return req
+}
+
+func TestRoundTrip_SuccessOnFirstAttempt(t *testing.T) {
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{statusCode: 200, body: "ok"},
+	}}
+	tr := &Transport{
+		Base:           stub,
+		MaxAttempts:    4,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     1 * time.Millisecond,
+	}
+	resp, err := tr.RoundTrip(newRequest(t, context.Background()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("got %d calls, want 1", got)
+	}
+}
+
+func TestRoundTrip_RetriesOn5xxThenSucceeds(t *testing.T) {
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{statusCode: 503, body: "unavailable"},
+		{statusCode: 502, body: "bad gateway"},
+		{statusCode: 200, body: "ok"},
+	}}
+	tr := &Transport{
+		Base:           stub,
+		MaxAttempts:    4,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     1 * time.Millisecond,
+	}
+	resp, err := tr.RoundTrip(newRequest(t, context.Background()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 3 {
+		t.Errorf("got %d calls, want 3", got)
+	}
+}
+
+func TestRoundTrip_RetriesOnNetworkErrorThenSucceeds(t *testing.T) {
+	netErr := errors.New("connection refused")
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{err: netErr},
+		{err: netErr},
+		{statusCode: 200, body: "ok"},
+	}}
+	tr := &Transport{
+		Base:           stub,
+		MaxAttempts:    4,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     1 * time.Millisecond,
+	}
+	resp, err := tr.RoundTrip(newRequest(t, context.Background()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 3 {
+		t.Errorf("got %d calls, want 3", got)
+	}
+}
+
+func TestRoundTrip_DoesNotRetryOn4xx(t *testing.T) {
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{statusCode: 404, body: "not found"},
+	}}
+	tr := &Transport{
+		Base:           stub,
+		MaxAttempts:    4,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     1 * time.Millisecond,
+	}
+	resp, err := tr.RoundTrip(newRequest(t, context.Background()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("got status %d, want 404", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("got %d calls, want 1 (4xx must not retry)", got)
+	}
+}
+
+func TestRoundTrip_GivesUpAfterMaxAttempts(t *testing.T) {
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{statusCode: 503}, {statusCode: 503}, {statusCode: 503},
+	}}
+	tr := &Transport{
+		Base:           stub,
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     1 * time.Millisecond,
+	}
+	resp, err := tr.RoundTrip(newRequest(t, context.Background()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 503 {
+		t.Errorf("got status %d, want 503 (last response surfaced)", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 3 {
+		t.Errorf("got %d calls, want exactly 3 (capped by MaxAttempts)", got)
+	}
+}
+
+func TestRoundTrip_HonorsContextCancellation(t *testing.T) {
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{statusCode: 503}, {statusCode: 503}, {statusCode: 503},
+	}}
+	tr := &Transport{
+		Base:           stub,
+		MaxAttempts:    4,
+		InitialBackoff: 200 * time.Millisecond, // long enough to observe cancel
+		MaxBackoff:     200 * time.Millisecond,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := tr.RoundTrip(newRequest(t, ctx))
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// Should have made fewer than 4 calls because ctx canceled mid-backoff.
+	if got := stub.calls.Load(); got >= 4 {
+		t.Errorf("got %d calls, expected fewer (context cancellation should short-circuit)", got)
+	}
+}
+
+// End-to-end test against a real httptest server: the renderer's actual
+// failure pattern (alternating EOF/500) gets recovered.
+func TestRoundTrip_EndToEndRecoversAlternatingFailures(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch n.Add(1) {
+		case 1:
+			// Simulate EOF mid-response: hijack the conn and close it.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("server: hijacker not available")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			_ = conn.Close()
+		case 2:
+			http.Error(w, "internal", http.StatusInternalServerError)
+		default:
+			_, _ = w.Write([]byte("ok"))
+		}
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: &Transport{
+			Base:           http.DefaultTransport,
+			MaxAttempts:    4,
+			InitialBackoff: 1 * time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+		},
+		Timeout: 2 * time.Second,
+	}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Errorf("got body %q, want %q", body, "ok")
+	}
+	if got := n.Load(); got != 3 {
+		t.Errorf("got %d server calls, want 3 (1 EOF + 1 500 + 1 success)", got)
+	}
+}

--- a/dras/internal/image/image.go
+++ b/dras/internal/image/image.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jacaudi/dras/internal/httpretry"
 	"github.com/jacaudi/dras/internal/logger"
 )
 
@@ -95,9 +96,17 @@ func New(cfg Config) *Service {
 		retention = DefaultRetention
 	}
 
+	// When no HTTPClient is supplied, install a default that wraps
+	// http.DefaultTransport with httpretry.Transport. This absorbs
+	// transient upstream NWS flakiness — DNS hiccups, 5xx, timeouts
+	// mid-request — without callers seeing them as fetch failures.
+	// Issue #101 / #103.
 	client := cfg.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: defaultTimeout}
+		client = &http.Client{
+			Timeout:   defaultTimeout,
+			Transport: httpretry.DefaultTransport(),
+		}
 	}
 
 	return &Service{

--- a/dras/internal/renderer/client.go
+++ b/dras/internal/renderer/client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jacaudi/dras/internal/httpretry"
 	"github.com/jacaudi/dras/internal/image"
 	"github.com/jacaudi/dras/internal/logger"
 )
@@ -38,13 +39,22 @@ type Client struct {
 }
 
 // New constructs a Client. Panics on empty BaseURL.
+//
+// When cfg.HTTPClient is nil, the default client wraps http.DefaultTransport
+// with httpretry.Transport so cold-start races (renderer pod still binding),
+// transient 5xx (502/503/504/500), 408/429, and network-layer errors (EOF
+// from a worker that hit OOM mid-request, connection refused) are
+// transparently retried with exponential backoff. Issue #101 / #103.
 func New(cfg Config) *Client {
 	if cfg.BaseURL == "" {
 		panic("renderer.New: BaseURL is required")
 	}
 	hc := cfg.HTTPClient
 	if hc == nil {
-		hc = &http.Client{Timeout: cfg.Timeout}
+		hc = &http.Client{
+			Timeout:   cfg.Timeout,
+			Transport: httpretry.DefaultTransport(),
+		}
 	}
 	return &Client{
 		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),


### PR DESCRIPTION
## Summary

Closes #103 (renderer crash loop) and #101 (advanced-mode startup race + basic-mode upstream resilience).

Two-Deployment topology preserved. Resilience moves into the dras Go client layer where it covers ALL transient failures, not just startup.

## Chart-side (issue #103)

Production diagnosis on selfhosted cluster:

```
$ kubectl describe pod -n selfhosted -l app.kubernetes.io/controller=renderer
Last State: Terminated, Reason: OOMKilled, Exit Code: 137
Restart Count: 4 (in 43 min)

$ kubectl logs ...
mkdir -p failed for path /.config/matplotlib: [Errno 13] Permission denied: '/.config'

$ kubectl exec ... -- sh -c 'echo HOME=$HOME; ls -ld /home/renderer'
HOME=/
drwxr-xr-x. 1 renderer renderer 20 May 2 02:52 /home/renderer
```

Three compounding chart-default bugs:

1. **Wrong UID**: `defaultPodOptions.runAsUser: 65532` overrides the renderer image's `renderer` user (UID 10001). The warmed Cartopy Natural Earth shapefile cache at `/home/renderer/.local/share/cartopy` is unreachable to UID 65532.
2. **Memory too low**: 768Mi limit vs Py-ART's ~1.1Gi peak on KATX's larger Level II volumes → OOMKill mid-render → EOF observed by dras.
3. **HOME=/ permission errors**: matplotlib tries `mkdir /.config` on every startup; falls back to `/tmp` with a warning.

Fix in `chart/values.yaml`:

- New `controllers.renderer.pod.securityContext` block pinning `runAsUser/runAsGroup: 10001`. dras stays at the global 65532 (static Go binary; runs as anything).
- Renderer memory: requests 384Mi → 512Mi, limits 768Mi → **1536Mi**.
- Renderer container env: `MPLCONFIGDIR=/tmp/matplotlib` (writable tmpfs).
- New `persistence.tmp` (emptyDir, sizeLimit 256Mi) mounted at `/tmp` on each container via `advancedMounts` with **per-container `subPath`** (`dras` / `renderer`). Each pod has its own pod-scoped emptyDir; subPaths isolate the two containers if they're ever colocated, keep the rootfs read-only-ready, and make the cache lifecycle explicit.
- Helper strips `persistence.<*>.advancedMounts.renderer` in standard mode so bjw-s common doesn't bail with "No enabled controller found" when the renderer controller is unset.

Bonus in `chart/templates/_app-template-values.tpl`: mirror the dras-side `env: {map}` → list normalization to the renderer env-merge so operators can supply either form without `error calling append: Cannot push on type map`.

## Go-side (issue #101 + basic-mode resilience)

Issue #101's startup-race is just one instance of a broader problem: dras's HTTP fetches don't tolerate transient upstream failures. Same class of failure also hits basic mode when NWS upstream blips (DNS hiccup, transient 5xx, mid-response disconnect, S3 timeouts in renderer).

New package `internal/httpretry` — an `http.RoundTripper` that wraps `http.DefaultTransport` and retries transient failures with exponential backoff + full jitter. Defaults: 4 attempts, 1s → 30s capped backoff. Honors `Retry-After` on 429/503. Aborts immediately on context cancellation.

Retry policy:

| Condition | Retry? |
|---|---|
| Network error (connection refused, EOF, DNS failure, timeout) | ✅ |
| 5xx (500, 502, 503, 504) | ✅ |
| 408 Request Timeout | ✅ |
| 429 Too Many Requests | ✅ (Retry-After honored) |
| 4xx (other) | ❌ |
| 2xx, 3xx | ❌ |

Wired in:

- `renderer.New()` — default HTTPClient now wraps `httpretry.DefaultTransport()`.
- `image.New()` (basic-mode NWS fetcher) — same.

Both clients still accept a custom HTTPClient via Config — tests pass their own stubs unchanged. Production paths get the retry transport automatically. All requests are GETs; replay is always safe.

## Why this approach instead of an init container or sidecar refactor

- **Init container polling**: only delays first pod start. If the renderer crashes mid-day, the running dras pod still hits errors until renderer recovers. Doesn't address basic-mode upstream flakiness at all.
- **Sidecar refactor (collapse into one Deployment)**: works but throws out the two-Deployment topology and changes the chart's values shape significantly. Operator preference: keep two Deployments.
- **Client-side retry (this PR)**: covers cold-start AND mid-day failures AND basic-mode upstream blips. No topology change. Same fix benefits both modes.

## Verification

```
$ helm lint chart/ --strict
1 chart(s) linted, 0 chart(s) failed

$ helm unittest chart/   (× 5 consecutive runs)
Tests: 19 passed, 19 total   each run

$ helm template ... | kubeconform -strict -kubernetes-version 1.30.0
standard:  1 resource found, Valid: 1
advanced:  3 resources found, Valid: 3

$ go test ./...
all 10 packages pass

$ go vet ./... && gofmt -l .
clean
```

`internal/httpretry` adds 7 test cases including an end-to-end test against an `httptest.Server` that alternates EOF / 500 / 200 — the exact production failure pattern observed for KATX — and asserts recovery. helm-unittest gains assertions for the new `/tmp` mount + subPath isolation in both modes.

## Production mitigation while this rolls out

Apply the same chart values as a HelmRelease override in home-ops for an immediate fix without waiting on a chart release:

```yaml
controllers:
  renderer:
    pod:
      securityContext:
        runAsUser: 10001
        runAsGroup: 10001
        fsGroup: 10001
    containers:
      app:
        env:
          - { name: MPLCONFIGDIR, value: /tmp/matplotlib }
        resources:
          requests: { cpu: 100m, memory: 512Mi }
          limits:   { memory: 1536Mi }

persistence:
  tmp:
    enabled: true
    type: emptyDir
    sizeLimit: 256Mi
    advancedMounts:
      dras:
        app:
          - { path: /tmp, subPath: dras }
      renderer:
        app:
          - { path: /tmp, subPath: renderer }
```

The retry-transport portion ships only with the dras image rebuild from this PR's release; until then, the override above stops the OOMKill loop. The existing dras image will still occasionally surface EOF/500 errors until the new image is deployed.

## Test plan

- [x] `helm lint chart/ --strict` clean.
- [x] `helm unittest chart/` 19/19 deterministic across 5 runs.
- [x] kubeconform validates both modes against k8s 1.30.0.
- [x] `go test ./...` all 10 packages pass.
- [x] `go vet ./...` and `gofmt -l .` clean.
- [ ] After merge + release: deploy in selfhosted; verify renderer pod restart count stays at 0 over 24h, dras logs show no EOF/500 errors (any transient ones get retried out of the way before bubbling up as warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)