### PR TITLE
fix(dras): de-flake renderer 503 error-body surfacing test

### DIFF
--- a/dras/internal/renderer/client_test.go
+++ b/dras/internal/renderer/client_test.go
@@ -61,7 +61,11 @@ func TestFetchServerErrorReturnsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
+	// Inject a non-retrying client: this test covers structured-error-body
+	// surfacing, not retry behavior. The default transport retries 503 with
+	// backoff, which races the request timeout and produces a flaky
+	// "context deadline exceeded" instead of the renderer's error code.
+	c := New(Config{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: 5 * time.Second}})
 	_, err := c.Fetch(t.Context(), "KATX")
 	if err == nil {
 		t.Fatal("expected error")


### PR DESCRIPTION
## Summary

- Test was racing `httpretry`'s retry loop (added in #104) against the 5s client timeout. Renderer returns 503 for `no_recent_scan`; the retry transport retries 503 four times with backoff (1s+2s+4s+jitter), and depending on jitter the 5s timeout fires first — producing "context deadline exceeded" instead of the renderer's structured error code. Failed CI on `main` post-merge of #104 (run [25269499441](https://github.com/jacaudi/dras/actions/runs/25269499441)).
- Fix: inject a non-retrying `http.Client` in this test. It exercises error-body surfacing, not retry behavior — retry behavior has its own coverage in `internal/httpretry/transport_test.go`.

Locally reproduced the failure (`go test -count=10` hits it), then ran `-count=20` after the fix with no failures.

## Follow-up (separate concern, not addressed here)

In production, `no_recent_scan` (a non-transient condition: there is no recent scan) now incurs ~7s of retries before surfacing — the retry transport treats all 503s as transient. Options for a follow-up:

1. Map `no_recent_scan` to 404 in the renderer (`renderer/src/dras_renderer/app.py:32`). More semantically accurate; a renderer-API change.
2. Have the dras retry transport (or client) inspect the error body for known non-transient codes before retrying. Couples retry to the renderer's error vocabulary.

I'd lean (1). Happy to follow up either way.

## Test plan

- [x] `go test ./internal/renderer/ -count=20` passes
- [x] `go test ./...` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)