### PR TITLE
fix(renderer): map no_recent_scan to 404 instead of 503

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,8 +65,8 @@ Renderer error envelope: `{"error": "<code>", "detail": "<message>"}`.
 |---|---|---|
 | 400 | `unsupported_product` | Product is not `base_reflectivity`. |
 | 404 | `station_unknown` | Reserved; not currently emitted. |
+| 404 | `no_recent_scan` | No volume present in any slot for the station. |
 | 502 | `decode_failed` | Py-ART couldn't parse the assembled volume. |
-| 503 | `no_recent_scan` | No volume present in any slot for the station. |
 | 500 | `internal` | S3 listing/download failed (mapped from `S3Error`). |
 
 The dras-side renderer client surfaces the code and detail verbatim in its error string.

--- a/dras/internal/renderer/client_test.go
+++ b/dras/internal/renderer/client_test.go
@@ -61,7 +61,11 @@ func TestFetchServerErrorReturnsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(Config{BaseURL: srv.URL, Timeout: 5 * time.Second})
+	// Inject a non-retrying client: this test covers structured-error-body
+	// surfacing, not retry behavior. The default transport retries 503 with
+	// backoff, which races the request timeout and produces a flaky
+	// "context deadline exceeded" instead of the renderer's error code.
+	c := New(Config{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: 5 * time.Second}})
 	_, err := c.Fetch(t.Context(), "KATX")
 	if err == nil {
 		t.Fatal("expected error")

--- a/renderer/README.md
+++ b/renderer/README.md
@@ -44,8 +44,8 @@ Error responses use a stable envelope:
 |---|---|---|
 | 400 | `unsupported_product` | Product is not `base_reflectivity`. |
 | 404 | `station_unknown` | Reserved; not currently emitted. |
+| 404 | `no_recent_scan` | No volume present in any slot for the station. |
 | 502 | `decode_failed` | Py-ART couldn't parse the assembled volume. |
-| 503 | `no_recent_scan` | No volume present in any slot for the station. |
 | 500 | `internal` | S3 listing/download failed (mapped from `S3Error`). |
 
 `GET /healthz` — liveness/readiness probe; returns `{"status": "ok", "renderer_version": "..."}`.

--- a/renderer/src/dras_renderer/app.py
+++ b/renderer/src/dras_renderer/app.py
@@ -29,7 +29,7 @@ from dras_renderer.version import VERSION
 # HTTP status mapping per ServiceError.code.
 _STATUS_FOR_CODE: dict[str, int] = {
     "station_unknown": 404,
-    "no_recent_scan": 503,
+    "no_recent_scan": 404,
     "decode_failed": 502,
     "unsupported_product": 400,
     "internal": 500,

--- a/renderer/tests/test_render_route.py
+++ b/renderer/tests/test_render_route.py
@@ -51,7 +51,7 @@ def test_render_route_no_recent_volume() -> None:
         client = TestClient(build_app())
         resp = client.get("/render/KATX")
 
-    assert resp.status_code == 503
+    assert resp.status_code == 404
     body = resp.json()
     assert body["error"] == "no_recent_scan"
 


### PR DESCRIPTION
## Summary

- `no_recent_scan` is a non-transient condition (no recent volume exists for the station). Mapping it to 503 caused dras's `httpretry` transport (added in #104) to retry it 4× with exponential backoff (~7s of waste) before surfacing — all 5xx are treated as transient.
- Map it to 404, matching the semantic of `station_unknown` and the general "resource does not exist" meaning. The retry transport correctly skips 404, so dras surfaces the error immediately.
- Updates the renderer route test asserting status code, and the README + architecture doc status tables.

## Notes

- Stacks naturally with #105 (de-flake test). #105's test injection is harmless once this lands — keeps the dras test isolated to error-body surfacing rather than retry/timing.
- Renderer-side API change: any external HTTP consumer keying off 503 for this code will need to update. Within this monorepo, dras is the only consumer and it already keys off the structured `error` field, not the status.

## Test plan

- [x] `uv run pytest` — 36/36 passed
- [ ] CI green
- [ ] After merge, observe that dras `no_recent_scan` errors surface in <1s rather than ~7s

🤖 Generated with [Claude Code](https://claude.com/claude-code)