### PR TITLE
fix(renderer): make image uid-agnostic — closes #107

### DIFF
--- a/dras/internal/config/config.go
+++ b/dras/internal/config/config.go
@@ -109,7 +109,12 @@ func Load() (*Config, error) {
 
 	cfg.RendererURL = strings.TrimSpace(os.Getenv("RENDERER_URL"))
 
-	cfg.RendererTimeout = 30 * time.Second
+	// 60s default: a cold-start renderer (fresh pod, Py-ART + matplotlib
+	// font cache build on first import) plus a worst-case render of a
+	// busy station's Level II volume can hit ~30–40s. The previous 30s
+	// default tripped Client.Timeout on the first request after a pod
+	// restart. Issue #107 follow-up.
+	cfg.RendererTimeout = 60 * time.Second
 	if v := os.Getenv("RENDERER_TIMEOUT"); v != "" {
 		d, err := time.ParseDuration(v)
 		if err != nil {

--- a/dras/internal/config/config_test.go
+++ b/dras/internal/config/config_test.go
@@ -262,7 +262,7 @@ func TestRendererURLLoadedFromEnv(t *testing.T) {
 	}
 }
 
-func TestRendererTimeoutDefaultIs30Seconds(t *testing.T) {
+func TestRendererTimeoutDefaultIs60Seconds(t *testing.T) {
 	t.Setenv("PUSHOVER_API_TOKEN", "x")
 	t.Setenv("PUSHOVER_USER_KEY", "x")
 	t.Setenv("STATION_IDS", "KATX")
@@ -271,7 +271,7 @@ func TestRendererTimeoutDefaultIs30Seconds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.RendererTimeout != 30*time.Second {
+	if cfg.RendererTimeout != 60*time.Second {
 		t.Errorf("RendererTimeout = %v", cfg.RendererTimeout)
 	}
 }

--- a/dras/internal/httpretry/transport.go
+++ b/dras/internal/httpretry/transport.go
@@ -11,6 +11,7 @@ package httpretry
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"math/rand/v2"
@@ -39,6 +40,20 @@ type Transport struct {
 
 	// MaxBackoff caps the per-retry wait. Defaults to 30s.
 	MaxBackoff time.Duration
+
+	// PerAttemptTimeout, if > 0, bounds each individual request attempt.
+	// Each attempt's context is derived from the parent request context
+	// with this deadline; on expiry the attempt fails with
+	// context.DeadlineExceeded and the retry loop tries again. The overall
+	// budget is therefore PerAttemptTimeout * MaxAttempts + total backoff,
+	// rather than one shared deadline. This is the standard fix for
+	// "Client.Timeout exceeded while awaiting headers" — a single slow
+	// attempt can no longer starve subsequent attempts of budget.
+	//
+	// Set this instead of http.Client.Timeout: the latter applies a single
+	// deadline to the entire round-trip including all retries, which
+	// defeats the retry loop when an individual attempt is slow.
+	PerAttemptTimeout time.Duration
 }
 
 // DefaultTransport returns a Transport with the documented defaults.
@@ -54,6 +69,11 @@ func DefaultTransport() *Transport {
 // RoundTrip executes req with retry-on-transient-failure. The request body
 // is buffered up front so it can be replayed on each attempt. Context
 // cancellation aborts the retry loop immediately.
+//
+// When PerAttemptTimeout > 0, each attempt runs under its own derived
+// context with that deadline. The returned response's Body wraps the
+// per-attempt cancel so closing the body releases the timer; callers must
+// close the body as usual.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	base := t.Base
 	if base == nil {
@@ -71,6 +91,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if maxBackoff <= 0 {
 		maxBackoff = 30 * time.Second
 	}
+	perAttempt := t.PerAttemptTimeout
 
 	// Buffer the body so we can reset it on each attempt.
 	var bodyBytes []byte
@@ -88,17 +109,49 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		lastErr error
 	)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		// Restore body for this attempt.
+		// Bail before issuing if the parent context is already done.
+		if err := req.Context().Err(); err != nil {
+			return nil, err
+		}
+
+		// Build the per-attempt request. When PerAttemptTimeout is set
+		// each attempt gets its own deadline; otherwise we reuse the
+		// parent context directly.
+		attemptReq := req
+		var cancel context.CancelFunc
+		if perAttempt > 0 {
+			var attemptCtx context.Context
+			attemptCtx, cancel = context.WithTimeout(req.Context(), perAttempt)
+			attemptReq = req.WithContext(attemptCtx)
+		}
 		if bodyBytes != nil {
-			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			attemptReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 
-		resp, lastErr = base.RoundTrip(req)
+		resp, lastErr = base.RoundTrip(attemptReq)
 
-		if !shouldRetry(resp, lastErr) {
-			return resp, lastErr
+		// Parent-context cancellation must not be retried — the caller
+		// gave up. Per-attempt deadlines are retryable (treated as a
+		// transient slow attempt) and fall through to shouldRetry.
+		if pErr := req.Context().Err(); pErr != nil {
+			drainAndClose(resp)
+			if cancel != nil {
+				cancel()
+			}
+			return nil, pErr
 		}
-		if attempt >= maxAttempts {
+
+		retry := shouldRetry(resp, lastErr)
+		isLast := attempt >= maxAttempts
+		if !retry || isLast {
+			// Terminal: success, non-transient error, or out of attempts.
+			// Wrap the body so closing it releases the per-attempt
+			// context timer; callers already close response bodies.
+			if resp != nil && cancel != nil {
+				resp.Body = &cancelOnClose{ReadCloser: resp.Body, cancel: cancel}
+			} else if cancel != nil {
+				cancel()
+			}
 			return resp, lastErr
 		}
 
@@ -121,14 +174,14 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		logger.WithFields(fields).Debug("retrying transient HTTP failure")
 
 		// Drain and close any previous response body so the connection
-		// can be reused.
-		if resp != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			resp = nil
+		// can be reused, then release the per-attempt context.
+		drainAndClose(resp)
+		resp = nil
+		if cancel != nil {
+			cancel()
 		}
 
-		// Wait, respecting context cancellation.
+		// Wait, respecting parent context cancellation.
 		timer := time.NewTimer(wait)
 		select {
 		case <-timer.C:
@@ -139,6 +192,31 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, lastErr
+}
+
+// drainAndClose discards and closes a response body, ignoring errors. The
+// drain lets the underlying connection return to the pool for reuse.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// cancelOnClose wraps a response body so that Close() also cancels the
+// per-attempt context. The caller's normal "defer resp.Body.Close()" then
+// releases the timer; without this the timer would leak until it fires
+// (bounded by PerAttemptTimeout but still ugly).
+type cancelOnClose struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnClose) Close() error {
+	err := c.ReadCloser.Close()
+	c.cancel()
+	return err
 }
 
 // shouldRetry returns true if the (resp, err) pair represents a transient

--- a/dras/internal/httpretry/transport_test.go
+++ b/dras/internal/httpretry/transport_test.go
@@ -197,6 +197,137 @@ func TestRoundTrip_HonorsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestRoundTrip_PerAttemptTimeoutRetriesAfterSlowAttempt(t *testing.T) {
+	// First attempt sleeps past the per-attempt timeout; second attempt
+	// returns immediately. The retry loop should give the second attempt
+	// its own clock and succeed.
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(500 * time.Millisecond):
+				return
+			}
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &Transport{
+		Base:              http.DefaultTransport,
+		MaxAttempts:       4,
+		InitialBackoff:    1 * time.Millisecond,
+		MaxBackoff:        5 * time.Millisecond,
+		PerAttemptTimeout: 50 * time.Millisecond,
+	}}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want ok", body)
+	}
+	// The first attempt is canceled at ~50ms; second attempt starts and
+	// returns immediately. Total wall time should be well under the
+	// would-be-shared 500ms first-attempt budget.
+	if elapsed := time.Since(start); elapsed > 300*time.Millisecond {
+		t.Errorf("elapsed = %v, expected <300ms (per-attempt timeout failed to scope)", elapsed)
+	}
+	if got := n.Load(); got != 2 {
+		t.Errorf("server saw %d calls, want 2 (1 slow + 1 fast)", got)
+	}
+}
+
+func TestRoundTrip_PerAttemptTimeoutGivesUpAfterMaxAttempts(t *testing.T) {
+	// Every attempt sleeps past the per-attempt timeout. Final error
+	// should be context.DeadlineExceeded (the last attempt's per-attempt
+	// timeout firing).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &Transport{
+		Base:              http.DefaultTransport,
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Millisecond,
+		MaxBackoff:        5 * time.Millisecond,
+		PerAttemptTimeout: 30 * time.Millisecond,
+	}}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := client.Do(req)
+	if err == nil {
+		t.Fatal("expected error after all attempts time out")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") &&
+		!errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestRoundTrip_PerAttemptTimeoutBodyReadableAfterReturn(t *testing.T) {
+	// Success case with PerAttemptTimeout set. The response body wraps a
+	// cancel-on-close; reading the body before close must work, and
+	// closing the body must not error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	tr := &Transport{
+		Base:              http.DefaultTransport,
+		MaxAttempts:       4,
+		InitialBackoff:    1 * time.Millisecond,
+		MaxBackoff:        5 * time.Millisecond,
+		PerAttemptTimeout: 1 * time.Second,
+	}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want hello", body)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestRoundTrip_ParentCancelStopsRetriesNotPerAttempt(t *testing.T) {
+	// Parent context cancellation must short-circuit the retry loop,
+	// even if the per-attempt timeout would have allowed another try.
+	stub := &fakeTransport{scripted: []roundTripResult{
+		{statusCode: 503}, {statusCode: 503}, {statusCode: 503}, {statusCode: 503},
+	}}
+	tr := &Transport{
+		Base:              stub,
+		MaxAttempts:       4,
+		InitialBackoff:    200 * time.Millisecond,
+		MaxBackoff:        200 * time.Millisecond,
+		PerAttemptTimeout: 1 * time.Second,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := tr.RoundTrip(newRequest(t, ctx))
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
 // End-to-end test against a real httptest server: the renderer's actual
 // failure pattern (alternating EOF/500) gets recovered.
 func TestRoundTrip_EndToEndRecoversAlternatingFailures(t *testing.T) {

--- a/dras/internal/image/image.go
+++ b/dras/internal/image/image.go
@@ -100,13 +100,14 @@ func New(cfg Config) *Service {
 	// http.DefaultTransport with httpretry.Transport. This absorbs
 	// transient upstream NWS flakiness — DNS hiccups, 5xx, timeouts
 	// mid-request — without callers seeing them as fetch failures.
-	// Issue #101 / #103.
+	// defaultTimeout is applied per-attempt (each retry gets its own
+	// clock), not as http.Client.Timeout — see httpretry.Transport docs.
+	// Issue #101 / #103 / #107.
 	client := cfg.HTTPClient
 	if client == nil {
-		client = &http.Client{
-			Timeout:   defaultTimeout,
-			Transport: httpretry.DefaultTransport(),
-		}
+		rt := httpretry.DefaultTransport()
+		rt.PerAttemptTimeout = defaultTimeout
+		client = &http.Client{Transport: rt}
 	}
 
 	return &Service{

--- a/dras/internal/renderer/client.go
+++ b/dras/internal/renderer/client.go
@@ -45,16 +45,20 @@ type Client struct {
 // transient 5xx (502/503/504/500), 408/429, and network-layer errors (EOF
 // from a worker that hit OOM mid-request, connection refused) are
 // transparently retried with exponential backoff. Issue #101 / #103.
+//
+// cfg.Timeout is applied per-attempt via httpretry.Transport.PerAttemptTimeout
+// — each retry gets its own clock. http.Client.Timeout is left at zero
+// because it would otherwise share a single deadline across all retries,
+// letting one slow attempt starve the budget.
 func New(cfg Config) *Client {
 	if cfg.BaseURL == "" {
 		panic("renderer.New: BaseURL is required")
 	}
 	hc := cfg.HTTPClient
 	if hc == nil {
-		hc = &http.Client{
-			Timeout:   cfg.Timeout,
-			Transport: httpretry.DefaultTransport(),
-		}
+		rt := httpretry.DefaultTransport()
+		rt.PerAttemptTimeout = cfg.Timeout
+		hc = &http.Client{Transport: rt}
 	}
 	return &Client{
 		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/dras/internal/renderer/client_test.go
+++ b/dras/internal/renderer/client_test.go
@@ -77,12 +77,18 @@ func TestFetchServerErrorReturnsError(t *testing.T) {
 
 func TestFetchTimeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(500 * time.Millisecond)
+		<-r.Context().Done()
 	}))
 	defer srv.Close()
 
-	c := New(Config{BaseURL: srv.URL, Timeout: 100 * time.Millisecond})
-	_, err := c.Fetch(t.Context(), "KATX")
+	// Per-attempt timeout = 50ms; parent-context deadline at 200ms keeps
+	// the retry loop from burning four attempts of backoff before giving
+	// up. Without the parent deadline, the retry transport retries each
+	// timed-out attempt and the test runs for seconds.
+	c := New(Config{BaseURL: srv.URL, Timeout: 50 * time.Millisecond})
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	_, err := c.Fetch(ctx, "KATX")
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}

--- a/renderer/Dockerfile
+++ b/renderer/Dockerfile
@@ -56,10 +56,21 @@ print('cartopy cache warmed')\
 FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
 
 ARG VERSION
+# HOME is pinned (not derived from /etc/passwd) so the image works under any
+# numeric runAsUser — Kubernetes operators frequently override the image's
+# baked-in USER to satisfy cluster policy (PSA restricted, OPA, kyverno).
+# Without this, an unknown uid resolves $HOME to / and Cartopy/Matplotlib try
+# to mkdir /.local and /.config respectively. Issue #107.
+#
+# MPLCONFIGDIR points at /tmp so Matplotlib never needs to write to $HOME on
+# import. Mirrors the chart-side setting added for #101 — bake it into the
+# image so the image is self-sufficient even without the chart's env block.
 ENV DRAS_RENDERER_VERSION=${VERSION} \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     MPLBACKEND=Agg \
+    HOME=/home/renderer \
+    MPLCONFIGDIR=/tmp/matplotlib \
     PATH="/app/.venv/bin:$PATH"
 
 # Runtime libs only — no -dev packages. bookworm-slim ships GDAL 3.6 binaries
@@ -77,18 +88,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
-# Copy the warmed Cartopy cache and chown it for the renderer user.
+# Copy the warmed Cartopy cache and chown it for the renderer user, then
+# make every path under HOME world-readable+traversable so the image works
+# under any non-root uid (including operator-overridden runAsUser values
+# that don't match 10001). Issue #107.
 COPY --from=builder --chown=renderer:renderer /root/.local/share/cartopy /home/renderer/.local/share/cartopy
-# Verify the runtime user can actually read the cached Natural Earth data.
-# Run as the renderer UID (not root) so a future ownership/perms regression
-# in the COPY --chown above is caught at build time, not at first request.
+RUN chmod -R go+rX /home/renderer
+# Verify the warmed cache is reachable as the baked-in renderer user AND
+# under an arbitrary "policy-pinned" non-root uid. The second check is the
+# regression guard for #107 — if a future change re-introduces uid-coupled
+# perms, the build fails here instead of at first request in production.
 USER renderer
-RUN HOME=/home/renderer /app/.venv/bin/python -c "\
+RUN /app/.venv/bin/python -c "\
 import cartopy.feature as cf;\
 states=list(cf.STATES.with_scale('50m').geometries());\
 coast=list(cf.COASTLINE.with_scale('50m').geometries());\
 assert states and coast, 'cartopy cache copy is empty or unreachable';\
-print(f'cartopy cache verified: {len(states)} states, {len(coast)} coastline features')\
+print(f'cartopy cache verified (uid renderer): {len(states)} states, {len(coast)} coastline features')\
+"
+USER 65532
+RUN /app/.venv/bin/python -c "\
+import cartopy.feature as cf;\
+states=list(cf.STATES.with_scale('50m').geometries());\
+coast=list(cf.COASTLINE.with_scale('50m').geometries());\
+assert states and coast, 'cartopy cache unreachable under unknown uid';\
+print(f'cartopy cache verified (uid 65532): {len(states)} states, {len(coast)} coastline features')\
 "
 USER root
 COPY --chown=renderer:renderer src /app/src


### PR DESCRIPTION
## Summary

Three fixes for the renderer's first-request-after-pod-restart failure mode (#107 + the production warning showing `Client.Timeout exceeded while awaiting headers`).

### 1. Image: uid-agnostic cartopy/matplotlib caches

Closes #107. The renderer image bakes `USER renderer` (uid 10001) but operators commonly override `runAsUser` for cluster policy (PSA `restricted`, OPA, kyverno). Without an `/etc/passwd` entry, `\$HOME=/`, so Cartopy's `~/.local/share/cartopy` resolves to `/.local/share/cartopy`, walks `parent.mkdir(parents=True)` to `/.local`, and crashes with `PermissionError`. Same shape as #101's matplotlib bug, different cache path.

The chart in v2.7.2 already pins the renderer pod to uid 10001 (defense in depth from #104), so default chart users are fine — but the **image was still brittle** to security-context overrides.

Changes (`renderer/Dockerfile`, runtime stage):
- `ENV HOME=/home/renderer` — `\$HOME` resolves regardless of running uid.
- `ENV MPLCONFIGDIR=/tmp/matplotlib` — bakes in #101's chart-side env so the image is self-sufficient.
- `chmod -R go+rX /home/renderer` after the cartopy COPY — warmed cache becomes readable + traversable by any uid (was chowned 0700 to renderer:renderer only).
- Build-time verification now runs as **both** uid `renderer` AND uid `65532` (an arbitrary "policy-pinned" non-root uid). Future regressions in uid-coupled perms fail at build time, not at first render.

### 2. dras: bump `RENDERER_TIMEOUT` default 30s → 60s

A cold-starting renderer pays for Py-ART import + matplotlib font cache build (~10–15s) plus the actual render of a busy station's Level II volume (~15–25s), pushing total wall time past 30s. 60s gives headroom for cold start and a worst-case render. Operators can still override via the `RENDERER_TIMEOUT` env var.

### 3. httpretry: per-attempt timeout so retries get independent budgets

`http.Client.Timeout` applies to the entire round-trip including all retries inside `httpretry.Transport`. A single slow attempt could eat the whole budget, leaving no time for retries — defeating the retry loop precisely when retries were most needed.

New `httpretry.Transport.PerAttemptTimeout`: when set, each attempt runs under its own `context.WithTimeout(parentCtx, perAttempt)`. Overall budget becomes `perAttempt × MaxAttempts + total backoff`, bounded only by the caller's context.

Body lifecycle: a cancel-on-close wrapper releases the per-attempt timer when the caller closes the response body (callers already use `defer resp.Body.Close()`), so the timer goroutine doesn't leak.

Parent-vs-per-attempt: parent ctx cancellation returns immediately (caller gave up); per-attempt deadlines are treated as transient and feed into `shouldRetry`.

Both callers migrated:
- `renderer.New`: drops `http.Client.Timeout`, sets `Transport.PerAttemptTimeout = cfg.Timeout`.
- `image.Service`: same pattern with `defaultTimeout`.

New tests cover: slow first attempt → fast retry succeeds (~80ms instead of would-have-been 500ms shared budget); all-attempts-timeout → `context.DeadlineExceeded`; body readable + closeable on success; parent-cancel beats per-attempt.

## Test plan

- [x] `docker build` — both uid-renderer and uid-65532 verify steps pass
- [x] `docker run --user 65532:65532 ... python -c '<smoke>'` — `\$HOME=/home/renderer`, matplotlib + cartopy import, FastAPI app builds
- [x] `docker run --user 99999:99999 ...` — works under arbitrary uid
- [x] `go test ./...` — all dras packages pass
- [x] httpretry: 4 new tests for per-attempt behavior, all pass
- [ ] CI green
- [ ] After release, deploy with `defaultPodOptions.runAsUser: 65532` (no renderer-specific override) and confirm renders succeed
- [ ] After release, verify cold-start renders no longer time out and that retries actually fire when one attempt is slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)