### PR TITLE
feat(renderer): freshness improvements — TTL, data_age_seconds, PNG title

### DIFF
--- a/renderer/src/dras_renderer/app.py
+++ b/renderer/src/dras_renderer/app.py
@@ -44,6 +44,7 @@ class MetadataModel(BaseModel):
     elevation_deg: float
     vcp: int
     renderer_version: str
+    data_age_seconds: float
 
 
 class RenderEnvelope(BaseModel):
@@ -119,6 +120,7 @@ def build_app(config: Config | None = None) -> FastAPI:
                 elevation_deg=resp.metadata.elevation_deg,
                 vcp=resp.metadata.vcp,
                 renderer_version=resp.metadata.renderer_version,
+                data_age_seconds=resp.metadata.data_age_at_render,
             ),
         )
 

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -20,6 +20,8 @@ import cartopy.feature as cfeature  # type: ignore[import-untyped]
 import cartopy.io.shapereader as shapereader  # type: ignore[import-untyped]
 import matplotlib.pyplot as plt
 import pyart  # type: ignore[import-untyped]
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from dras_renderer.decode import DecodedScan
 
@@ -78,79 +80,23 @@ class RenderOptions:
     cities_max_scalerank: int = 8
 
 
-def render_base_reflectivity(scan: DecodedScan, opts: RenderOptions) -> bytes:
+def render_base_reflectivity(
+    scan: DecodedScan,
+    opts: RenderOptions,
+    *,
+    data_age_seconds: float | None = None,
+) -> bytes:
     """Render the lowest-tilt base reflectivity as a PPI on a Cartopy basemap.
 
     Returns PNG bytes sized exactly to ``(opts.width, opts.height)``.
+
+    When ``data_age_seconds`` is provided, the axes title is overridden to
+    show both the volume start time (``scan.scan_time``) and the freshest
+    chunk's age at render time, so callers can see "+Δ Ns" at a glance.
+    When ``None``, Py-ART's default title is left intact.
     """
-    fig = plt.figure(
-        figsize=(opts.width / opts.dpi, opts.height / opts.dpi),
-        dpi=opts.dpi,
-    )
+    fig, _ax = _render_figure(scan, opts, data_age_seconds)
     try:
-        radar = scan.radar
-        radar_lat = float(radar.latitude["data"][0])
-        radar_lon = float(radar.longitude["data"][0])
-
-        center_lat = opts.center_lat if opts.center_lat is not None else radar_lat
-        center_lon = opts.center_lon if opts.center_lon is not None else radar_lon
-
-        projection = ccrs.LambertConformal(
-            central_latitude=center_lat,
-            central_longitude=center_lon,
-        )
-        ax = fig.add_subplot(1, 1, 1, projection=projection)
-
-        # 1° lat ≈ 111 km everywhere; 1° lon ≈ 111 cos(lat) km. Without the
-        # cos(lat) correction the east-west extent stretches by 33% at KATX
-        # (lat ~48°) and ~50% at high-latitude AK stations.
-        delta_lat = opts.range_km / 111.0
-        delta_lon = delta_lat / max(math.cos(math.radians(center_lat)), 1e-6)
-        extent = (
-            center_lon - delta_lon,
-            center_lon + delta_lon,
-            center_lat - delta_lat,
-            center_lat + delta_lat,
-        )
-        ax.set_extent(extent, crs=ccrs.PlateCarree())
-
-        # Basemap layers, drawn from bottom up.
-        if opts.show_lakes:
-            ax.add_feature(
-                cfeature.LAKES.with_scale("50m"),
-                facecolor="none",
-                edgecolor="#4a6da7",
-                linewidth=0.4,
-            )
-        ax.add_feature(cfeature.STATES.with_scale("50m"), edgecolor="gray", linewidth=0.5)
-        ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
-        if opts.show_borders:
-            ax.add_feature(
-                cfeature.BORDERS.with_scale("50m"),
-                edgecolor="gray",
-                linewidth=0.5,
-            )
-
-        gatefilter = _build_clutter_filter(radar, opts) if opts.clutter_filter else None
-
-        display = pyart.graph.RadarMapDisplay(radar)
-        # sweep=0 == lowest tilt: Py-ART sorts sweeps by ascending elevation.
-        display.plot_ppi_map(
-            "reflectivity",
-            sweep=0,
-            ax=ax,
-            gatefilter=gatefilter,
-            colorbar_flag=False,
-            title_flag=True,
-            vmin=opts.vmin,
-            vmax=opts.vmax,
-            cmap="pyart_NWSRef",
-            embellish=False,  # We add our own basemap features above.
-        )
-
-        if opts.show_cities:
-            _add_cities(ax, extent, max_scalerank=opts.cities_max_scalerank)
-
         buf = io.BytesIO()
         # IMPORTANT: do NOT pass bbox_inches="tight" — it crops to content
         # and produces non-deterministic output dimensions, which would
@@ -160,6 +106,96 @@ def render_base_reflectivity(scan: DecodedScan, opts: RenderOptions) -> bytes:
         return buf.getvalue()
     finally:
         plt.close(fig)
+
+
+def _render_figure(
+    scan: DecodedScan,
+    opts: RenderOptions,
+    data_age_seconds: float | None,
+) -> tuple[Figure, Axes]:
+    """Build the matplotlib figure + axes for a render.
+
+    Split out from ``render_base_reflectivity`` so tests can introspect the
+    axes (title, artists) before the figure is closed. The caller owns the
+    returned ``Figure`` and is responsible for calling ``plt.close(fig)``.
+    """
+    fig = plt.figure(
+        figsize=(opts.width / opts.dpi, opts.height / opts.dpi),
+        dpi=opts.dpi,
+    )
+    radar = scan.radar
+    radar_lat = float(radar.latitude["data"][0])
+    radar_lon = float(radar.longitude["data"][0])
+
+    center_lat = opts.center_lat if opts.center_lat is not None else radar_lat
+    center_lon = opts.center_lon if opts.center_lon is not None else radar_lon
+
+    projection = ccrs.LambertConformal(
+        central_latitude=center_lat,
+        central_longitude=center_lon,
+    )
+    ax = fig.add_subplot(1, 1, 1, projection=projection)
+
+    # 1° lat ≈ 111 km everywhere; 1° lon ≈ 111 cos(lat) km. Without the
+    # cos(lat) correction the east-west extent stretches by 33% at KATX
+    # (lat ~48°) and ~50% at high-latitude AK stations.
+    delta_lat = opts.range_km / 111.0
+    delta_lon = delta_lat / max(math.cos(math.radians(center_lat)), 1e-6)
+    extent = (
+        center_lon - delta_lon,
+        center_lon + delta_lon,
+        center_lat - delta_lat,
+        center_lat + delta_lat,
+    )
+    ax.set_extent(extent, crs=ccrs.PlateCarree())
+
+    # Basemap layers, drawn from bottom up.
+    if opts.show_lakes:
+        ax.add_feature(
+            cfeature.LAKES.with_scale("50m"),
+            facecolor="none",
+            edgecolor="#4a6da7",
+            linewidth=0.4,
+        )
+    ax.add_feature(cfeature.STATES.with_scale("50m"), edgecolor="gray", linewidth=0.5)
+    ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
+    if opts.show_borders:
+        ax.add_feature(
+            cfeature.BORDERS.with_scale("50m"),
+            edgecolor="gray",
+            linewidth=0.5,
+        )
+
+    gatefilter = _build_clutter_filter(radar, opts) if opts.clutter_filter else None
+
+    display = pyart.graph.RadarMapDisplay(radar)
+    # sweep=0 == lowest tilt: Py-ART sorts sweeps by ascending elevation.
+    display.plot_ppi_map(
+        "reflectivity",
+        sweep=0,
+        ax=ax,
+        gatefilter=gatefilter,
+        colorbar_flag=False,
+        title_flag=True,
+        vmin=opts.vmin,
+        vmax=opts.vmax,
+        cmap="pyart_NWSRef",
+        embellish=False,  # We add our own basemap features above.
+    )
+
+    # Override Py-ART's default title to surface both the volume start time
+    # and the freshest-chunk age — answers "is this image stale?" at a glance.
+    # MUST come after plot_ppi_map, which sets its own title via title_flag=True.
+    if data_age_seconds is not None:
+        ax.set_title(
+            f"{scan.station_id} {scan.elevation_deg:.1f} Deg. "
+            f"{scan.scan_time.isoformat()}  +Δ {data_age_seconds:.0f}s"
+        )
+
+    if opts.show_cities:
+        _add_cities(ax, extent, max_scalerank=opts.cities_max_scalerank)
+
+    return fig, ax
 
 
 def _build_clutter_filter(radar: Any, opts: RenderOptions) -> Any:

--- a/renderer/src/dras_renderer/s3.py
+++ b/renderer/src/dras_renderer/s3.py
@@ -42,7 +42,9 @@ class LatestVolume:
     station_id: str
     volume_number: int
     chunk_keys: tuple[str, ...]  # sorted by chunk-num (== lex order due to zero-padding)
-    latest_chunk_time: datetime
+    latest_chunk_time: datetime  # volume START (parsed from chunk filename ts prefix)
+    # Max S3 LastModified across the winning slot's filtered chunks.
+    latest_chunk_uploaded_at: datetime
 
 
 def _make_config(anonymous: bool) -> BotocoreConfig:
@@ -107,18 +109,23 @@ class S3Client:
         return result
 
     def _compute_latest_volume(self, station_id: str) -> LatestVolume | None:
-        def chunks_for(vol_num: int) -> tuple[int, list[str]]:
+        def chunks_for(vol_num: int) -> tuple[int, list[tuple[str, datetime]]]:
             return vol_num, self._list_keys(f"{station_id}/{vol_num}/")
 
         with ThreadPoolExecutor(max_workers=self.list_workers) as executor:
             results = list(executor.map(chunks_for, VOLUME_SLOTS))
 
-        # ``sorted(keys)`` orders chunks by lex; chunk filenames are
+        # Sort each slot's entries by key (lex). Chunk filenames are
         # ``<YYYYMMDD-HHMMSS>-<NNN>-<TYPE>``, where the chunk-num field is
         # zero-padded to 3 digits. Within a single volume's keys this makes
         # lex order == chronological / chunk-num order. If NOAA ever drops
         # the zero-pad, parse the chunk-num explicitly via ``int(name.rsplit("-", 2)[-2])``.
-        non_empty = [(v, sorted(keys)) for v, keys in results if keys]
+        # ``last_modified`` rides along on each tuple; we don't sort by it.
+        non_empty = [
+            (v, sorted(entries, key=lambda kt: kt[0]))
+            for v, entries in results
+            if entries
+        ]
         if not non_empty:
             return None
 
@@ -126,16 +133,19 @@ class S3Client:
         # filename — defensive against future drift in the chunk-num/type
         # suffix format (e.g. a per-tilt suffix change). The volume start
         # timestamp is what determines recency.
-        def prefix_key(item: tuple[int, list[str]]) -> str:
-            return item[1][-1].rsplit("/", 1)[-1][:15]
+        def prefix_key(item: tuple[int, list[tuple[str, datetime]]]) -> str:
+            return item[1][-1][0].rsplit("/", 1)[-1][:15]
 
-        best_vol, best_chunks = max(non_empty, key=prefix_key)
-        ts_prefix = prefix_key((best_vol, best_chunks))  # "YYYYMMDD-HHMMSS"
+        best_vol, best_entries = max(non_empty, key=prefix_key)
+        ts_prefix = prefix_key((best_vol, best_entries))  # "YYYYMMDD-HHMMSS"
         # Slots are reused (volume IDs cycle 0-999). A slot mid-overwrite can hold
         # chunks from two distinct volumes; keep only the winning volume's chunks.
-        volume_chunks = tuple(
-            k for k in best_chunks if k.rsplit("/", 1)[-1].startswith(ts_prefix)
-        )
+        winning_filtered = [
+            (k, lm) for (k, lm) in best_entries
+            if k.rsplit("/", 1)[-1].startswith(ts_prefix)
+        ]
+        volume_chunks = tuple(k for (k, _lm) in winning_filtered)
+        latest_uploaded_at = max(lm for (_k, lm) in winning_filtered)
         latest_time = datetime.strptime(ts_prefix, "%Y%m%d-%H%M%S").replace(tzinfo=UTC)
 
         return LatestVolume(
@@ -143,6 +153,7 @@ class S3Client:
             volume_number=best_vol,
             chunk_keys=volume_chunks,
             latest_chunk_time=latest_time,
+            latest_chunk_uploaded_at=latest_uploaded_at,
         )
 
     def download_volume(self, volume: LatestVolume) -> bytes:
@@ -178,14 +189,19 @@ class S3Client:
 
         return b"".join(bodies)
 
-    def _list_keys(self, prefix: str) -> list[str]:
-        keys: list[str] = []
+    def _list_keys(self, prefix: str) -> list[tuple[str, datetime]]:
+        """List object (key, LastModified) pairs under ``prefix``.
+
+        ``LastModified`` is a tz-aware datetime that boto3's paginator already
+        surfaces in each ``Contents`` entry — no extra HEAD/GET round trip.
+        """
+        entries: list[tuple[str, datetime]] = []
         paginator = self._client.get_paginator("list_objects_v2")
         try:
             for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
                 for entry in page.get("Contents", []):
-                    keys.append(entry["Key"])
+                    entries.append((entry["Key"], entry["LastModified"]))
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "")
             raise S3Error(f"S3 list_objects_v2 failed on {prefix}: {code}") from e
-        return keys
+        return entries

--- a/renderer/src/dras_renderer/s3.py
+++ b/renderer/src/dras_renderer/s3.py
@@ -68,7 +68,7 @@ class S3Client:
         anonymous: bool = True,
         list_workers: int = 64,
         download_workers: int | None = None,
-        latest_volume_ttl: float = 30.0,
+        latest_volume_ttl: float = 5.0,
     ) -> None:
         self.bucket = bucket
         self.region = region
@@ -80,8 +80,12 @@ class S3Client:
         self._client: Any = boto3.client(
             "s3", region_name=region, config=_make_config(anonymous)
         )
-        # Negative results (None for unknown stations) are cached too — that's
-        # deliberate, to suppress 1000-LIST fan-out on typo'd station IDs.
+        # Short TTL amortizes the 1000-LIST fan-out across back-to-back renders
+        # (hot-loop coalescing) without masking new chunks: NEXRAD chunks land
+        # every few seconds, so 5s keeps freshness perception correct while still
+        # collapsing duplicate work in tight render loops. Negative results
+        # (None for unknown stations) are cached too — deliberate, to suppress
+        # the 1000-LIST fan-out on typo'd station IDs.
         self._latest_cache: TTLCache[str, LatestVolume | None] = TTLCache(
             maxsize=256, ttl=latest_volume_ttl,
         )

--- a/renderer/src/dras_renderer/service.py
+++ b/renderer/src/dras_renderer/service.py
@@ -143,7 +143,7 @@ class RenderService:
             # data_age_at_render reflects the freshness perceived by callers.
             render_time = datetime.now(UTC)
             data_age = (render_time - volume.latest_chunk_uploaded_at).total_seconds()
-            png = render_base_reflectivity(decoded, opts)
+            png = render_base_reflectivity(decoded, opts, data_age_seconds=data_age)
 
             meta = RenderMetadata(
                 station=req.station,

--- a/renderer/src/dras_renderer/service.py
+++ b/renderer/src/dras_renderer/service.py
@@ -113,9 +113,13 @@ class RenderService:
             if cached_png is not None and cached_meta is not None:
                 # Recompute data_age_at_render so the cached envelope reports
                 # current age, not the age at the time of the original render.
-                fresh_age = (
-                    datetime.now(UTC) - volume.latest_chunk_uploaded_at
-                ).total_seconds()
+                # Clamp at 0 to absorb sub-second NTP skew between the local
+                # clock and S3's LastModified clock — a "-0.4s" age would be
+                # honest but useless and renders awkwardly in the PNG title.
+                fresh_age = max(
+                    0.0,
+                    (datetime.now(UTC) - volume.latest_chunk_uploaded_at).total_seconds(),
+                )
                 return RenderResponse(
                     png=cached_png,
                     metadata=replace(cached_meta, data_age_at_render=fresh_age),
@@ -142,7 +146,10 @@ class RenderService:
             # Capture render_time as close to the render call as possible so
             # data_age_at_render reflects the freshness perceived by callers.
             render_time = datetime.now(UTC)
-            data_age = (render_time - volume.latest_chunk_uploaded_at).total_seconds()
+            data_age = max(
+                0.0,
+                (render_time - volume.latest_chunk_uploaded_at).total_seconds(),
+            )
             png = render_base_reflectivity(decoded, opts, data_age_seconds=data_age)
 
             meta = RenderMetadata(

--- a/renderer/src/dras_renderer/service.py
+++ b/renderer/src/dras_renderer/service.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
-from datetime import datetime
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
 
 from cachetools import LRUCache
 
@@ -36,6 +36,10 @@ class RenderMetadata:
     elevation_deg: float
     vcp: int
     renderer_version: str
+    # Seconds elapsed between the newest chunk's S3 LastModified and the moment
+    # we (re)entered the rendering step. Recomputed on cache hits so the value
+    # always reflects "right now", not when the PNG was rendered.
+    data_age_at_render: float
 
 
 @dataclass(frozen=True)
@@ -107,7 +111,15 @@ class RenderService:
             cached_png = self._cache.get(req.station, cache_key)
             cached_meta = self._meta.get((req.station, cache_key))
             if cached_png is not None and cached_meta is not None:
-                return RenderResponse(png=cached_png, metadata=cached_meta)
+                # Recompute data_age_at_render so the cached envelope reports
+                # current age, not the age at the time of the original render.
+                fresh_age = (
+                    datetime.now(UTC) - volume.latest_chunk_uploaded_at
+                ).total_seconds()
+                return RenderResponse(
+                    png=cached_png,
+                    metadata=replace(cached_meta, data_age_at_render=fresh_age),
+                )
 
             try:
                 volume_bytes = self._s3.download_volume(volume)
@@ -127,6 +139,10 @@ class RenderService:
                 center_lat=req.center_lat,
                 center_lon=req.center_lon,
             )
+            # Capture render_time as close to the render call as possible so
+            # data_age_at_render reflects the freshness perceived by callers.
+            render_time = datetime.now(UTC)
+            data_age = (render_time - volume.latest_chunk_uploaded_at).total_seconds()
             png = render_base_reflectivity(decoded, opts)
 
             meta = RenderMetadata(
@@ -136,6 +152,7 @@ class RenderService:
                 elevation_deg=decoded.elevation_deg,
                 vcp=decoded.vcp,
                 renderer_version=VERSION,
+                data_age_at_render=data_age,
             )
             self._cache.set(req.station, cache_key, png)
             self._meta[(req.station, cache_key)] = meta

--- a/renderer/tests/test_app_health.py
+++ b/renderer/tests/test_app_health.py
@@ -29,6 +29,7 @@ def test_render_response_scan_time_is_iso8601() -> None:
         elevation_deg=0.5,
         vcp=212,
         renderer_version="test",
+        data_age_at_render=1.5,
     )
     fake_resp = RenderResponse(png=b"\x89PNG\r\n\x1a\n", metadata=fake_meta)
 

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -83,8 +83,9 @@ def test_render_title_includes_scan_time_and_data_age(decoded: DecodedScan) -> N
         plt.close(fig)
 
     assert decoded.scan_time.isoformat() in title
-    assert "+Δ" in title  # "+Δ"
-    assert "30s" in title
+    # Pin the joined token so a future format drift (e.g. dropping the Δ or
+    # the trailing "s") is caught, not just the substrings independently.
+    assert "+Δ 30s" in title
     assert decoded.station_id in title
 
 

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -6,11 +6,16 @@ import gzip
 import io
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pytest
 from PIL import Image
 
 from dras_renderer.decode import DecodedScan, decode_level2_archive
-from dras_renderer.render import RenderOptions, render_base_reflectivity
+from dras_renderer.render import (
+    RenderOptions,
+    _render_figure,
+    render_base_reflectivity,
+)
 
 FIXTURE = Path(__file__).parent / "fixtures" / "KATX_test.ar2v.gz"
 
@@ -62,6 +67,40 @@ def test_render_clutter_filter_changes_output(decoded: DecodedScan) -> None:
     filtered = render_base_reflectivity(decoded, RenderOptions(clutter_filter=True))
     raw = render_base_reflectivity(decoded, RenderOptions(clutter_filter=False))
     assert filtered != raw
+
+
+def test_render_title_includes_scan_time_and_data_age(decoded: DecodedScan) -> None:
+    """When data_age_seconds is provided, the axes title is overridden to
+    include the volume start (scan_time iso), the station id, and the
+    +Δ data-age annotation.
+
+    Uses 30.0 to dodge banker's-rounding ambiguity on .5 values.
+    """
+    fig, ax = _render_figure(decoded, RenderOptions(), data_age_seconds=30.0)
+    try:
+        title = ax.get_title()
+    finally:
+        plt.close(fig)
+
+    assert decoded.scan_time.isoformat() in title
+    assert "+Δ" in title  # "+Δ"
+    assert "30s" in title
+    assert decoded.station_id in title
+
+
+def test_render_default_title_unchanged_when_no_age(decoded: DecodedScan) -> None:
+    """Without data_age_seconds, leave Py-ART's default title intact —
+    don't pin the exact text (locks us to a Py-ART version), but assert
+    it's non-empty and lacks the "+Δ" annotation.
+    """
+    fig, ax = _render_figure(decoded, RenderOptions(), data_age_seconds=None)
+    try:
+        title = ax.get_title()
+    finally:
+        plt.close(fig)
+
+    assert title  # non-empty
+    assert "+Δ" not in title
 
 
 def test_matplotlib_uses_agg_backend() -> None:

--- a/renderer/tests/test_render_route.py
+++ b/renderer/tests/test_render_route.py
@@ -28,6 +28,7 @@ def _vol() -> LatestVolume:
         volume_number=492,
         chunk_keys=("KATX/492/20260501-180941-001-S",),
         latest_chunk_time=datetime(2026, 5, 1, 18, 9, 41, tzinfo=UTC),
+        latest_chunk_uploaded_at=datetime(2026, 5, 1, 18, 9, 50, tzinfo=UTC),
     )
 
 
@@ -44,6 +45,21 @@ def test_render_route_returns_envelope(fixture_bytes: bytes) -> None:
     assert body["metadata"]["renderer_version"]
     png_bytes = base64.b64decode(body["image"])
     assert png_bytes.startswith(b"\x89PNG")
+
+
+def test_render_route_includes_data_age_seconds(fixture_bytes: bytes) -> None:
+    """The response envelope must surface ``metadata.data_age_seconds``."""
+    with patch("dras_renderer.s3.S3Client.latest_volume", return_value=_vol()), \
+         patch("dras_renderer.s3.S3Client.download_volume", return_value=fixture_bytes):
+        client = TestClient(build_app())
+        resp = client.get("/render/KATX")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "data_age_seconds" in body["metadata"]
+    age = body["metadata"]["data_age_seconds"]
+    assert isinstance(age, (int, float))
+    assert age >= 0
 
 
 def test_render_route_no_recent_volume() -> None:

--- a/renderer/tests/test_s3.py
+++ b/renderer/tests/test_s3.py
@@ -76,6 +76,33 @@ def test_latest_volume_picks_max_chunk_timestamp(mock_bucket: str) -> None:
             "KATX/17/20260429-120500-002-I",
         )
         assert v.latest_chunk_time == datetime(2026, 4, 29, 12, 5, 0, tzinfo=UTC)
+        # moto sets LastModified to "now" at put time.
+        assert v.latest_chunk_uploaded_at.tzinfo is not None
+        assert v.latest_chunk_uploaded_at <= datetime.now(UTC)
+
+
+def test_latest_volume_uploaded_at_is_max_winning_chunk_lastmodified() -> None:
+    """``latest_chunk_uploaded_at`` must equal the max LastModified across the
+    winning slot's filtered chunks."""
+    import time
+
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=BUCKET)
+        # Two chunks in one slot, with a small delay so LastModified differs.
+        _put_chunk(s3, "KATX/4/20260429-120000-001-S", b"a")
+        time.sleep(0.05)
+        _put_chunk(s3, "KATX/4/20260429-120000-002-I", b"b")
+
+        # Read the actual LastModified of each chunk via list_objects_v2.
+        listing = s3.list_objects_v2(Bucket=BUCKET, Prefix="KATX/4/")
+        last_mods = {entry["Key"]: entry["LastModified"] for entry in listing["Contents"]}
+        expected_max = max(last_mods.values())
+
+        client = _make_client()
+        v = client.latest_volume("KATX")
+        assert v is not None
+        assert v.latest_chunk_uploaded_at == expected_max
 
 
 def test_latest_volume_returns_none_for_unknown_station(mock_bucket: str) -> None:

--- a/renderer/tests/test_s3.py
+++ b/renderer/tests/test_s3.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Iterator
 from datetime import UTC, datetime
 
@@ -15,6 +16,17 @@ from dras_renderer.s3 import (
     S3Error,
     VolumeNotFoundError,
 )
+
+
+def test_latest_volume_ttl_default_is_5_seconds() -> None:
+    """Lock the S3Client.latest_volume_ttl default at 5s.
+
+    The TTL exists to amortize the 1000-LIST fan-out across back-to-back
+    renders. Anything longer (the original 30s) can hide minute-old data
+    from the freshness checks. 5s still amortizes hot loops while keeping
+    user-visible freshness perception correct.
+    """
+    assert inspect.signature(S3Client).parameters["latest_volume_ttl"].default == 5.0
 
 BUCKET = "unidata-nexrad-level2-chunks"
 

--- a/renderer/tests/test_service.py
+++ b/renderer/tests/test_service.py
@@ -27,6 +27,7 @@ def _vol() -> LatestVolume:
         volume_number=492,
         chunk_keys=("KATX/492/20260501-180941-001-S",),
         latest_chunk_time=datetime(2026, 5, 1, 18, 9, 41, tzinfo=UTC),
+        latest_chunk_uploaded_at=datetime(2026, 5, 1, 18, 9, 50, tzinfo=UTC),
     )
 
 
@@ -107,6 +108,38 @@ def test_render_increments_s3_errors_on_list_failure() -> None:
     after = S3_ERRORS_TOTAL._value.get()  # type: ignore[attr-defined]
     assert after == before + 1
     s3.download_volume.assert_not_called()
+
+
+def test_metadata_includes_data_age_at_render_nonneg(fixture_bytes: bytes) -> None:
+    """``data_age_at_render`` is render_time - latest_chunk_uploaded_at and must be >= 0."""
+    s3 = MagicMock()
+    s3.latest_volume.return_value = _vol()
+    s3.download_volume.return_value = fixture_bytes
+
+    svc = RenderService(s3=s3, cache=RenderCache(max_size=8))
+    resp = svc.render(RenderRequest(station="KATX"))
+
+    assert isinstance(resp.metadata.data_age_at_render, float)
+    assert resp.metadata.data_age_at_render >= 0.0
+
+
+def test_cache_hit_recomputes_data_age(fixture_bytes: bytes) -> None:
+    """The cache short-circuits the s3 download but data age must reflect
+    the current request time, not the cached metadata's age."""
+    import time
+
+    s3 = MagicMock()
+    s3.latest_volume.return_value = _vol()
+    s3.download_volume.return_value = fixture_bytes
+
+    svc = RenderService(s3=s3, cache=RenderCache(max_size=8))
+    resp1 = svc.render(RenderRequest(station="KATX"))
+    time.sleep(0.05)
+    resp2 = svc.render(RenderRequest(station="KATX"))
+
+    assert s3.download_volume.call_count == 1  # second was a cache hit
+    assert resp1.metadata.data_age_at_render > 0.0
+    assert resp2.metadata.data_age_at_render > resp1.metadata.data_age_at_render
 
 
 def test_render_increments_s3_errors_on_download_failure() -> None:


### PR DESCRIPTION
## Summary

Three small, complementary changes to make "is this stale?" a non-question for the renderer:

1. **Lower `latest_volume_ttl` default 30s → 5s** (`s3.py`). The cache exists to amortize the 1000-LIST fan-out across back-to-back renders, not as a freshness policy. 5s still amortizes hot loops without masking minute-old chunks.
2. **Surface `data_age_seconds` in the response envelope.** The S3 client now retains each chunk's `LastModified` from the existing `list_objects_v2` paginator (no extra round trip), and exposes the max across the winning slot's filtered chunks as `LatestVolume.latest_chunk_uploaded_at`. The service captures `render_time = datetime.now(UTC)` immediately before the render call, computes `data_age = render_time - latest_chunk_uploaded_at`, and surfaces it as `metadata.data_age_seconds` in JSON. Cache-hit responses recompute the age so the cached envelope always reports current freshness.
3. **PNG title now shows both timestamps.** The Py-ART default title is overridden to `"<STATION> <ELEV> Deg. <scan_start_iso>  +Δ <data_age>s"`, so the volume start AND the freshness of the freshest chunk are visible on the rendered image itself.

In-progress-volume behavior is unchanged (intentional — partial-volume renders at 0.5° are still useful).

## Before / After

**Before:** A KATX render at 06:08 UTC reports `scan_time=2026-05-03T06:08:39Z` with no other timestamp. The user has to guess whether the data is fresh or whether the 30s LIST cache is hiding a newer volume.

**After:** Same render now reports `scan_time` AND `data_age_seconds: 12.4` (or whatever) in the JSON envelope. The PNG title reads `KATX 0.5 Deg. 2026-05-03T06:08:39+00:00  +Δ 12s`. The TTL is short enough that fresh chunks land in the next render within ~5s instead of waiting up to 30s.

## Test Plan

- [x] `cd renderer && uv run pytest -q` — 52 passed (45 baseline + 7 new)
- [x] `helm unittest chart/` — 22/22 passed
- [x] `docker build` from `renderer/` — succeeds; cartopy pre-warm + uid 65532 verify step still green
- [ ] Hit `/render/{station}` against a real station post-deploy; verify `metadata.data_age_seconds` is populated and the PNG title shows the +Δ annotation
- [ ] Tail kubectl logs and confirm no new errors / no behavior change on cache hit path

## Notes

- Negative `data_age_seconds` is clamped to 0 to absorb sub-second NTP skew between local clock and S3 LastModified — a "+Δ -1s" title would be honest but useless.
- `LatestVolume.latest_chunk_time` (volume start, parsed from filename prefix) is intentionally separate from the new `LatestVolume.latest_chunk_uploaded_at` (max LastModified). The former is still the cache key in `service.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)