### PR TITLE
fix(build): wire VERSION/BUILDTIME/REVISION/BRANCH end-to-end

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,6 +98,14 @@ jobs:
       # arm64 build to amd64 saves ~20s of arm-runner provisioning.
       arm64-runner: ubuntu-24.04
       version: ${{ needs.release.outputs.new-release-version-v }}
+      # Forward build-time metadata so the binary's startup banner reports
+      # real version/commit/branch values instead of the Dockerfile defaults
+      # ("development" / "unknown"). Closes #82.
+      build-args: |
+        VERSION=${{ needs.release.outputs.new-release-version }}
+        BUILDTIME=${{ github.event.head_commit.timestamp }}
+        REVISION=${{ github.sha }}
+        BRANCH=${{ github.ref_name }}
       tags: |
         ghcr.io/${{ github.repository }}:latest
         ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new-release-version-v }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,13 @@ version: 2
 project_name: dras
 builds:
   - dir: ./dras
-    main: ./main.go
+    main: .
     binary: dras
+    ldflags:
+      - -X github.com/jacaudi/dras/internal/version.Version={{.Version}}
+      - -X github.com/jacaudi/dras/internal/version.BuildTime={{.Date}}
+      - -X github.com/jacaudi/dras/internal/version.GitCommit={{.FullCommit}}
+      - -X github.com/jacaudi/dras/internal/version.GitBranch={{.Branch}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/dras/Dockerfile
+++ b/dras/Dockerfile
@@ -6,8 +6,9 @@ ARG TARGETARCH
 ARG TARGETVARIANT=""
 
 ARG VERSION="development"
-ARG BUILDTIME=""
-ARG REVISION=""
+ARG BUILDTIME="unknown"
+ARG REVISION="unknown"
+ARG BRANCH="unknown"
 
 # Set necessary environment variables for Go cross-compilation
 ENV GO111MODULE=on \
@@ -32,8 +33,9 @@ RUN go mod tidy
 RUN go build -ldflags "\
     -X github.com/jacaudi/dras/internal/version.Version=${VERSION} \
     -X github.com/jacaudi/dras/internal/version.BuildTime=${BUILDTIME} \
-    -X github.com/jacaudi/dras/internal/version.GitCommit=${REVISION}" \
-    -o dras main.go
+    -X github.com/jacaudi/dras/internal/version.GitCommit=${REVISION} \
+    -X github.com/jacaudi/dras/internal/version.GitBranch=${BRANCH}" \
+    -o dras .
 
 # Final Stage
 FROM scratch AS final

--- a/dras/internal/version/version.go
+++ b/dras/internal/version/version.go
@@ -3,6 +3,8 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
+	"strings"
 )
 
 // Build information set via ldflags during compilation
@@ -23,9 +25,51 @@ type Info struct {
 	GoVersion string `json:"go_version"`
 }
 
-// Get returns the version information
+// Get returns the version information, applying a runtime/debug fallback
+// for VCS metadata when ldflags weren't set (e.g. `go install`, local
+// `go build` from a git workdir).
 func Get() Info {
-	return Info{Version, BuildTime, GitCommit, GitBranch, GoVersion}
+	bi, _ := debug.ReadBuildInfo()
+	return resolveInfo(Version, BuildTime, GitCommit, GitBranch, GoVersion, bi)
+}
+
+// resolveInfo picks the most-specific value for each field. Priority:
+//
+//	ldflag-set value > runtime/debug VCS info > the original "development"/"unknown" sentinels.
+//
+// Split out from Get() so it's unit-testable without re-binding package vars
+// or shelling out to `go build`.
+func resolveInfo(version, buildTime, commit, branch, goVersion string, bi *debug.BuildInfo) Info {
+	info := Info{
+		Version:   version,
+		BuildTime: buildTime,
+		GitCommit: commit,
+		GitBranch: branch,
+		GoVersion: goVersion,
+	}
+	if bi == nil {
+		return info
+	}
+	// Module-path version, set when installed via `go install pkg@vX.Y.Z`.
+	// "(devel)" is what `go build` writes for a non-tagged checkout.
+	if info.Version == "development" && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		info.Version = strings.TrimPrefix(bi.Main.Version, "v")
+	}
+	// VCS settings auto-embedded by `go build` since Go 1.18 when building in
+	// a git workdir. Only fill in when the ldflag-set value is still default.
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if info.GitCommit == "unknown" && s.Value != "" {
+				info.GitCommit = s.Value
+			}
+		case "vcs.time":
+			if info.BuildTime == "unknown" && s.Value != "" {
+				info.BuildTime = s.Value
+			}
+		}
+	}
+	return info
 }
 
 // String returns a formatted version string

--- a/dras/internal/version/version_test.go
+++ b/dras/internal/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -123,5 +124,88 @@ func TestDefaultValues(t *testing.T) {
 	}
 	if GoVersion != runtime.Version() {
 		t.Errorf("Expected GoVersion to be %s, got %s", runtime.Version(), GoVersion)
+	}
+}
+
+func TestResolveInfo(t *testing.T) {
+	const (
+		fakeRev  = "deadbeefcafebabe1234567890abcdef00000000"
+		fakeTime = "2026-05-03T15:00:00Z"
+	)
+	tests := []struct {
+		name                                    string
+		version, buildTime, commit, branch, gov string
+		bi                                      *debug.BuildInfo
+		want                                    Info
+	}{
+		{
+			name:    "ldflags-set values win over VCS info",
+			version: "2.9.0", buildTime: "2026-05-03T14:00:00Z",
+			commit: "abc123", branch: "main", gov: "go1.24.0",
+			bi: &debug.BuildInfo{
+				Main: debug.Module{Version: "v9.9.9"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: fakeRev},
+					{Key: "vcs.time", Value: fakeTime},
+				},
+			},
+			want: Info{Version: "2.9.0", BuildTime: "2026-05-03T14:00:00Z", GitCommit: "abc123", GitBranch: "main", GoVersion: "go1.24.0"},
+		},
+		{
+			name:    "VCS revision/time fill in when ldflags are default",
+			version: "development", buildTime: "unknown",
+			commit: "unknown", branch: "unknown", gov: "go1.24.0",
+			bi: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: fakeRev},
+					{Key: "vcs.time", Value: fakeTime},
+				},
+			},
+			want: Info{Version: "development", BuildTime: fakeTime, GitCommit: fakeRev, GitBranch: "unknown", GoVersion: "go1.24.0"},
+		},
+		{
+			name:    "module path version fills in when ldflag Version is default",
+			version: "development", buildTime: "unknown", commit: "unknown", branch: "unknown", gov: "go1.24.0",
+			bi: &debug.BuildInfo{
+				Main:     debug.Module{Version: "v1.2.3"},
+				Settings: nil,
+			},
+			want: Info{Version: "1.2.3", BuildTime: "unknown", GitCommit: "unknown", GitBranch: "unknown", GoVersion: "go1.24.0"},
+		},
+		{
+			name:    "nil BuildInfo returns inputs verbatim",
+			version: "development", buildTime: "unknown", commit: "unknown", branch: "unknown", gov: "go1.24.0",
+			bi:   nil,
+			want: Info{Version: "development", BuildTime: "unknown", GitCommit: "unknown", GitBranch: "unknown", GoVersion: "go1.24.0"},
+		},
+		{
+			name:    "(devel) module version is ignored",
+			version: "development", buildTime: "unknown", commit: "unknown", branch: "unknown", gov: "go1.24.0",
+			bi: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+			},
+			want: Info{Version: "development", BuildTime: "unknown", GitCommit: "unknown", GitBranch: "unknown", GoVersion: "go1.24.0"},
+		},
+		{
+			name:    "empty VCS values do not overwrite",
+			version: "development", buildTime: "unknown", commit: "unknown", branch: "unknown", gov: "go1.24.0",
+			bi: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: ""},
+					{Key: "vcs.time", Value: ""},
+				},
+			},
+			want: Info{Version: "development", BuildTime: "unknown", GitCommit: "unknown", GitBranch: "unknown", GoVersion: "go1.24.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveInfo(tt.version, tt.buildTime, tt.commit, tt.branch, tt.gov, tt.bi)
+			if got != tt.want {
+				t.Errorf("resolveInfo() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #82. Also unblocks the post-#79 release that failed on main (commit \`e6b5335\`).

## Problem

The startup banner in published containers reported:
\`\`\`
DRAS development (commit: , branch: unknown, go: go1.26.2)
\`\`\`

Two distinct bugs surfaced:
1. **Build-args never reached the container** — \`ci-cd.yml\` calls a reusable workflow that DOES accept \`build-args\`, but our call site never set them. Dockerfile defaults (\`VERSION=development\`, empty \`REVISION\`/\`BUILDTIME\`) took effect.
2. **\`GitBranch\` was never wired** — declared in the version package but no Dockerfile ARG / ldflag / CI step ever set it.
3. **(Bonus, found in flight)** — \`go build -o dras main.go\` and goreleaser's \`main: ./main.go\` both build only one file, missing the new \`logging.go\` from #79. The post-#79 release on main FAILED with \`undefined: fatal\` / \`undefined: newLogger\`. v2.9.x didn't ship.

## Changes

1. **\`dras/internal/version/version.go\`** — \`Get()\` now falls back to \`runtime/debug.ReadBuildInfo()\` for VCS metadata when ldflags weren't set. Covers \`go build\` / \`go install\` from a git workdir. Ldflag-set values still take precedence; the helper \`resolveInfo\` is unit-tested with 6 scenarios.
2. **\`dras/Dockerfile\`** — adds \`ARG BRANCH=\"unknown\"\` and a 4th \`-X ...GitBranch=\${BRANCH}\` ldflag. Defaults BUILDTIME/REVISION to \`\"unknown\"\` to match the Go package defaults. Fixes \`-o dras main.go\` → \`-o dras .\` so the package's other files (logging.go) compile.
3. **\`.goreleaser.yaml\`** — same \`-o main.go\` → \`.\` fix. Adds an \`ldflags:\` block templated with goreleaser's built-in \`{{.Version}}\`, \`{{.Date}}\`, \`{{.FullCommit}}\`, \`{{.Branch}}\` so the released binary also gets correct metadata.
4. **\`.github/workflows/ci-cd.yml\`** — adds \`build-args:\` to the \`container-dras\` job, forwarding \`VERSION\`/\`BUILDTIME\`/\`REVISION\`/\`BRANCH\` from \`needs.release.outputs.*\` and \`github.*\`. Reusable workflow already exposes that input — no upstream change needed.

## Verified locally

\`\`\`
$ go build -o dras . && ./dras
DRAS development (commit: e6b5335cd88e5531f6477e88d083336946918a20, branch: unknown, go: go1.26.2)
\`\`\`
Commit now populated from runtime/debug VCS info — no ldflags needed.

\`\`\`
$ docker build --build-arg VERSION=2.10.0 --build-arg BUILDTIME=2026-05-03T15:00:00Z \\
    --build-arg REVISION=abc123def456 --build-arg BRANCH=main -t dras:test .
$ docker run --rm dras:test
DRAS v2.10.0 (built: 2026-05-03T15:00:00Z, commit: abc123def456, go: go1.26.2)
\`\`\`

## Test plan

- [x] \`go vet ./... && go test ./...\` — all 9 packages pass; 6 new TestResolveInfo scenarios cover ldflag-priority, VCS fallback, module-path-version, nil BuildInfo, \"(devel)\" sentinel, and empty-VCS-value cases.
- [x] Local \`docker build\` with build-args produces correct banner (above).
- [ ] Post-merge: confirm v2.10.0 release publishes (#79's release failure reason fixed by goreleaser \`main: .\` change).
- [ ] Post-deploy: confirm \`kubectl logs\` for the \`dras\` pod shows real version/commit/branch in the startup banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)