### PR TITLE
feat(renderer): visual upgrade — basemap, deconflicted labels, furniture, footer

### DIFF
--- a/renderer/README.md
+++ b/renderer/README.md
@@ -31,8 +31,8 @@ Query parameters (all optional):
 |---|---|---|---|
 | `product` | `base_reflectivity` | — | Only value supported in v1. |
 | `range_km` | `230` | `[10, 460]` | Render extent radius. 460 is the Level II max unambiguous range. |
-| `width` | `800` | `[200, 4000]` | Output PNG width. |
-| `height` | `800` | `[200, 4000]` | Output PNG height. |
+| `width` | `1000` | `[200, 4000]` | Output PNG width. |
+| `height` | `1000` | `[200, 4000]` | Radar plot height; total PNG height adds an ~8% footer strip. |
 
 Error responses use a stable envelope:
 
@@ -54,6 +54,43 @@ Error responses use a stable envelope:
 - `renderer_requests_total{outcome=...}` — request counter labeled `ok` or `error_<code>`.
 - `renderer_render_duration_seconds` — end-to-end render histogram (100ms–60s buckets).
 - `renderer_s3_errors_total` — S3 list/download failure counter.
+
+## View presets
+
+The `?view=<name>` query parameter applies an opinionated framing for a
+station (recenter + zoom). Presets are opt-in — without `?view=`, the
+renderer centers on the radar with the default `range_km`.
+
+Currently defined:
+
+| Station | View    | Center               | Range  |
+|---------|---------|----------------------|--------|
+| KATX    | `metro` | 47.61°N, -122.33°E   | 70 km  |
+
+Example:
+
+```
+GET /render/KATX?view=metro
+```
+
+### Adding a view preset
+
+View presets live in `src/dras_renderer/station_views.py`. To add a new
+framing for a station:
+
+1. Append an entry to `_VIEWS` keyed on `(station_id, view_name)`.
+2. Set `center_lat`, `center_lon`, and `range_km` to your desired framing.
+3. Add a row to the table above.
+
+Example — adding a Bay Area view for KMUX:
+
+```python
+("KMUX", "metro"): StationView(
+    center_lat=37.77,
+    center_lon=-122.42,
+    range_km=70.0,
+),
+```
 
 ## Local development
 

--- a/renderer/pyproject.toml
+++ b/renderer/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "boto3>=1.35,<2",
     "botocore>=1.35,<2",
     "arm-pyart>=1.18,<2",
+    "adjustText>=1.2,<2",
     "matplotlib>=3.9,<4",
     "cartopy>=0.24,<0.25",
     "numpy>=1.26,<3",

--- a/renderer/src/dras_renderer/app.py
+++ b/renderer/src/dras_renderer/app.py
@@ -70,8 +70,19 @@ def build_app(config: Config | None = None) -> FastAPI:
         station: str,
         product: str = Query("base_reflectivity"),
         range_km: float = Query(230.0, ge=10.0, le=460.0),
-        width: int = Query(1000, ge=200, le=4000),
-        height: int = Query(1000, ge=200, le=4000),
+        width: int = Query(
+            1000, ge=200, le=4000,
+            description="Returned PNG width in pixels.",
+        ),
+        height: int = Query(
+            1000, ge=200, le=4000,
+            description=(
+                "Radar plot height in pixels. The returned PNG total "
+                "height equals this value plus an ~8% footer strip "
+                "(unless the renderer is invoked internally with "
+                "show_footer=False)."
+            ),
+        ),
         # Optional center override (decimal degrees, WGS84). When omitted
         # the view centers on the radar.
         center_lat: float | None = Query(None, ge=-90.0, le=90.0),

--- a/renderer/src/dras_renderer/app.py
+++ b/renderer/src/dras_renderer/app.py
@@ -70,8 +70,8 @@ def build_app(config: Config | None = None) -> FastAPI:
         station: str,
         product: str = Query("base_reflectivity"),
         range_km: float = Query(230.0, ge=10.0, le=460.0),
-        width: int = Query(800, ge=200, le=4000),
-        height: int = Query(800, ge=200, le=4000),
+        width: int = Query(1000, ge=200, le=4000),
+        height: int = Query(1000, ge=200, le=4000),
         # Optional center override (decimal degrees, WGS84). When omitted
         # the view centers on the radar.
         center_lat: float | None = Query(None, ge=-90.0, le=90.0),

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -8,16 +8,19 @@ unless documented otherwise. Loaders that read shapefiles wrap them in
 
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import cartopy.io.shapereader as shapereader
+from adjustText import adjust_text
 from cartopy.feature import ShapelyFeature
 from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
 from matplotlib.patheffects import withStroke
 from shapely.geometry import box as _shapely_box
+from shapely.geometry.base import BaseGeometry
 
 # Color palette — single source of truth for the renderer's look.
 LAND_COLOR = "#f5f0e6"      # warm cream
@@ -63,7 +66,7 @@ def add_land_water_fill(
 
 
 @lru_cache(maxsize=1)
-def _county_records() -> tuple:
+def _county_records() -> tuple[BaseGeometry, ...]:
     """Load Natural Earth admin_2_counties_lakes (10m), cached.
 
     Returns a tuple of shapely geometries. We strip attributes — we don't
@@ -101,12 +104,12 @@ _INTERSTATE_CLASSES = frozenset({"Major Highway", "Beltway"})
 
 
 @lru_cache(maxsize=1)
-def _road_records() -> tuple:
+def _road_records() -> tuple[tuple[BaseGeometry, str], ...]:
     """Load Natural Earth roads (10m), cached. Returns ((geometry, class), ...)."""
     path = shapereader.natural_earth(
         category="cultural", name="roads", resolution="10m"
     )
-    out: list[tuple] = []
+    out: list[tuple[BaseGeometry, str]] = []
     for record in shapereader.Reader(path).records():
         attrs = record.attributes
         road_class = attrs.get("type") or attrs.get("TYPE") or ""
@@ -208,9 +211,6 @@ def add_cities(
     failure (e.g., degenerate layouts) and fall back to halo-only
     placement — the labels are still readable, just possibly overlapping.
     """
-    import logging
-    from adjustText import adjust_text
-
     west, east, south, north = extent
     texts = []
     for lon0, lat0, name, scalerank in _populated_places_records():

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -16,6 +16,7 @@ import cartopy.io.shapereader as shapereader
 from cartopy.feature import ShapelyFeature
 from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
+from shapely.geometry import box as _shapely_box
 
 # Color palette — single source of truth for the renderer's look.
 LAND_COLOR = "#f5f0e6"      # warm cream
@@ -88,3 +89,74 @@ def add_counties(ax: Axes) -> None:
         linewidth=0.3,
     )
     ax.add_feature(feat, zorder=2)
+
+
+# Road classes we keep (filters out local/residential/unclassified). The
+# Natural Earth roads dataset's "type" attribute uses these category names.
+_KEEP_ROAD_CLASSES = frozenset(
+    {"Major Highway", "Secondary Highway", "Beltway", "Bypass"}
+)
+_INTERSTATE_CLASSES = frozenset({"Major Highway", "Beltway"})
+
+
+@lru_cache(maxsize=1)
+def _road_records() -> tuple:
+    """Load Natural Earth roads (10m), cached. Returns ((geometry, class), ...)."""
+    path = shapereader.natural_earth(
+        category="cultural", name="roads", resolution="10m"
+    )
+    out: list[tuple] = []
+    for record in shapereader.Reader(path).records():
+        attrs = record.attributes
+        road_class = attrs.get("type") or attrs.get("TYPE") or ""
+        if road_class not in _KEEP_ROAD_CLASSES:
+            continue
+        out.append((record.geometry, road_class))
+    return tuple(out)
+
+
+def add_roads(
+    ax: Axes, extent: tuple[float, float, float, float]
+) -> None:
+    """Draw highways inside ``extent``: interstates dull-red, others gray.
+
+    Geometries are pre-filtered against ``extent`` with a shapely box so
+    we don't ask matplotlib to draw segments that fall entirely outside
+    the visible area.
+    """
+    west, east, south, north = extent
+    bbox = _shapely_box(west, south, east, north)
+
+    interstates: list = []
+    secondaries: list = []
+    for geom, road_class in _road_records():
+        if not geom.intersects(bbox):
+            continue
+        if road_class in _INTERSTATE_CLASSES:
+            interstates.append(geom)
+        else:
+            secondaries.append(geom)
+
+    if secondaries:
+        ax.add_feature(
+            ShapelyFeature(
+                secondaries,
+                ccrs.PlateCarree(),
+                facecolor="none",
+                edgecolor=SECONDARY_ROAD_COLOR,
+                linewidth=0.5,
+            ),
+            zorder=4,
+        )
+    if interstates:
+        # Drawn after secondaries so interstates win at intersections.
+        ax.add_feature(
+            ShapelyFeature(
+                interstates,
+                ccrs.PlateCarree(),
+                facecolor="none",
+                edgecolor=INTERSTATE_COLOR,
+                linewidth=0.9,
+            ),
+            zorder=4,
+        )

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -1,0 +1,9 @@
+"""Basemap layer helpers for the radar PPI render.
+
+Each function takes a Cartopy GeoAxes and adds one layer. Functions are
+pure with respect to the axes (they mutate it) and have no return value
+unless documented otherwise. Loaders that read shapefiles wrap them in
+@lru_cache(maxsize=1) so repeated renders don't re-read disk.
+"""
+
+from __future__ import annotations

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -10,17 +10,17 @@ from __future__ import annotations
 
 import logging
 from functools import lru_cache
+from typing import Any
 
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
-import cartopy.io.shapereader as shapereader
-from adjustText import adjust_text
+import cartopy.crs as ccrs  # type: ignore[import-untyped]
+import cartopy.feature as cfeature  # type: ignore[import-untyped]
+import cartopy.io.shapereader as shapereader  # type: ignore[import-untyped]
+from adjustText import adjust_text  # type: ignore[import-untyped]
 from cartopy.feature import ShapelyFeature
-from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
 from matplotlib.patheffects import withStroke
-from shapely.geometry import box as _shapely_box
-from shapely.geometry.base import BaseGeometry
+from shapely.geometry import box as _shapely_box  # type: ignore[import-untyped]
+from shapely.geometry.base import BaseGeometry  # type: ignore[import-untyped]
 
 # Color palette — single source of truth for the renderer's look.
 LAND_COLOR = "#f5f0e6"      # warm cream
@@ -33,7 +33,7 @@ SECONDARY_ROAD_COLOR = "#888888"
 
 
 def add_land_water_fill(
-    ax: Axes, extent: tuple[float, float, float, float]
+    ax: Any, extent: tuple[float, float, float, float]
 ) -> None:
     """Paint the entire extent with WATER_COLOR, then overlay land polygons.
 
@@ -78,7 +78,7 @@ def _county_records() -> tuple[BaseGeometry, ...]:
     return tuple(record.geometry for record in shapereader.Reader(path).records())
 
 
-def add_counties(ax: Axes) -> None:
+def add_counties(ax: Any) -> None:
     """Draw US county boundaries as thin gray lines under states.
 
     Counties shape comes from Natural Earth admin_2_counties_lakes (10m),
@@ -120,7 +120,7 @@ def _road_records() -> tuple[tuple[BaseGeometry, str], ...]:
 
 
 def add_roads(
-    ax: Axes, extent: tuple[float, float, float, float]
+    ax: Any, extent: tuple[float, float, float, float]
 ) -> None:
     """Draw highways inside ``extent``: interstates dull-red, others gray.
 
@@ -131,8 +131,8 @@ def add_roads(
     west, east, south, north = extent
     bbox = _shapely_box(west, south, east, north)
 
-    interstates: list = []
-    secondaries: list = []
+    interstates: list[BaseGeometry] = []
+    secondaries: list[BaseGeometry] = []
     for geom, road_class in _road_records():
         if not geom.intersects(bbox):
             continue
@@ -195,7 +195,7 @@ def _populated_places_records() -> tuple[tuple[float, float, str, int], ...]:
 
 
 def add_cities(
-    ax: Axes,
+    ax: Any,
     extent: tuple[float, float, float, float],
     max_scalerank: int,
     *,

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -16,6 +16,7 @@ import cartopy.io.shapereader as shapereader
 from cartopy.feature import ShapelyFeature
 from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
+from matplotlib.patheffects import withStroke
 from shapely.geometry import box as _shapely_box
 
 # Color palette — single source of truth for the renderer's look.
@@ -191,34 +192,57 @@ def _populated_places_records() -> tuple[tuple[float, float, str, int], ...]:
 
 
 def add_cities(
-    ax: Axes, extent: tuple[float, float, float, float], max_scalerank: int
+    ax: Axes,
+    extent: tuple[float, float, float, float],
+    max_scalerank: int,
+    *,
+    deconflict: bool = True,
 ) -> None:
-    """Plot Natural Earth populated places that lie inside the extent.
+    """Plot Natural Earth populated places inside ``extent``.
 
-    Filters by SCALERANK so dense metros don't drown the map in labels.
+    All labels get a white halo via ``path_effects.withStroke`` so they
+    stay legible when they fall over reflectivity colors.
+
+    When ``deconflict`` is True, ``adjustText.adjust_text`` repositions
+    overlapping labels iteratively. We catch and log any adjustText
+    failure (e.g., degenerate layouts) and fall back to halo-only
+    placement — the labels are still readable, just possibly overlapping.
     """
+    import logging
+    from adjustText import adjust_text
+
     west, east, south, north = extent
+    texts = []
     for lon0, lat0, name, scalerank in _populated_places_records():
         if scalerank > max_scalerank:
             continue
         if not (west <= lon0 <= east and south <= lat0 <= north):
             continue
         ax.plot(
-            lon0,
-            lat0,
-            "o",
-            markersize=2.5,
-            color="black",
-            transform=ccrs.PlateCarree(),
-            zorder=5,
+            lon0, lat0, "o",
+            markersize=2.5, color="black",
+            transform=ccrs.PlateCarree(), zorder=5,
         )
-        ax.text(
-            lon0 + 0.04,
-            lat0 + 0.02,
-            name,
-            fontsize=7,
-            color="black",
-            transform=ccrs.PlateCarree(),
-            zorder=5,
+        t = ax.text(
+            lon0 + 0.04, lat0 + 0.02, name,
+            fontsize=7, color="black",
+            transform=ccrs.PlateCarree(), zorder=6,
             clip_on=True,
+            path_effects=[withStroke(linewidth=2, foreground="white")],
         )
+        texts.append(t)
+
+    if deconflict and texts:
+        try:
+            adjust_text(
+                texts,
+                ax=ax,
+                expand_points=(1.2, 1.4),
+                arrowprops=None,  # no leader lines in v1
+                only_move={"text": "xy"},
+            )
+        except Exception:  # pragma: no cover - defensive
+            logging.getLogger(__name__).warning(
+                "adjustText failed; falling back to halo-only placement",
+                exc_info=True,
+            )

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -7,3 +7,50 @@ unless documented otherwise. Loaders that read shapefiles wrap them in
 """
 
 from __future__ import annotations
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from matplotlib.axes import Axes
+from matplotlib.patches import Rectangle
+
+# Color palette — single source of truth for the renderer's look.
+LAND_COLOR = "#f5f0e6"      # warm cream
+WATER_COLOR = "#cfe6f3"     # light blue
+LAKE_OUTLINE = "#4a6da7"
+COUNTY_COLOR = "#d0d0d0"
+COASTLINE_COLOR = "#3a3a3a"
+INTERSTATE_COLOR = "#b04a3a"
+SECONDARY_ROAD_COLOR = "#888888"
+
+
+def add_land_water_fill(
+    ax: Axes, extent: tuple[float, float, float, float]
+) -> None:
+    """Paint the entire extent with WATER_COLOR, then overlay land polygons.
+
+    The ocean fill is a Rectangle in PlateCarree coords sized to ``extent``
+    and drawn at zorder=0 — Cartopy's OCEAN feature is unreliable for
+    inland waterways like Puget Sound (the Sound is technically tidal but
+    NE classifies it inconsistently across resolutions).
+
+    The land overlay then masks the ocean wherever there's land. This is
+    the same trick the NWS RIDGE basemap uses.
+    """
+    west, east, south, north = extent
+    ax.add_patch(
+        Rectangle(
+            (west, south),
+            east - west,
+            north - south,
+            facecolor=WATER_COLOR,
+            edgecolor="none",
+            transform=ccrs.PlateCarree(),
+            zorder=0,
+        )
+    )
+    ax.add_feature(
+        cfeature.LAND.with_scale("10m"),
+        facecolor=LAND_COLOR,
+        edgecolor="none",
+        zorder=1,
+    )

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -160,3 +160,65 @@ def add_roads(
             ),
             zorder=4,
         )
+
+
+@lru_cache(maxsize=1)
+def _populated_places_records() -> tuple[tuple[float, float, str, int], ...]:
+    """Load Natural Earth populated_places once.
+
+    Returns a tuple of (lon, lat, name, scalerank) tuples. Caching avoids
+    re-reading the shapefile on every render — the file is small but the
+    repeated I/O + shapely geometry construction is wasteful.
+    """
+    path = shapereader.natural_earth(
+        category="cultural", name="populated_places", resolution="10m"
+    )
+    out: list[tuple[float, float, str, int]] = []
+    for record in shapereader.Reader(path).records():
+        attrs = record.attributes
+        name = attrs.get("NAME") or attrs.get("name")
+        if not name:
+            continue
+        # SCALERANK is the Natural Earth "global importance" rank; lower
+        # = more prominent. 10 is the missing/sentinel value.
+        try:
+            scalerank = int(attrs.get("SCALERANK", 99))
+        except (TypeError, ValueError):
+            scalerank = 99
+        geom = record.geometry
+        out.append((float(geom.x), float(geom.y), str(name), scalerank))
+    return tuple(out)
+
+
+def add_cities(
+    ax: Axes, extent: tuple[float, float, float, float], max_scalerank: int
+) -> None:
+    """Plot Natural Earth populated places that lie inside the extent.
+
+    Filters by SCALERANK so dense metros don't drown the map in labels.
+    """
+    west, east, south, north = extent
+    for lon0, lat0, name, scalerank in _populated_places_records():
+        if scalerank > max_scalerank:
+            continue
+        if not (west <= lon0 <= east and south <= lat0 <= north):
+            continue
+        ax.plot(
+            lon0,
+            lat0,
+            "o",
+            markersize=2.5,
+            color="black",
+            transform=ccrs.PlateCarree(),
+            zorder=5,
+        )
+        ax.text(
+            lon0 + 0.04,
+            lat0 + 0.02,
+            name,
+            fontsize=7,
+            color="black",
+            transform=ccrs.PlateCarree(),
+            zorder=5,
+            clip_on=True,
+        )

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -8,8 +8,12 @@ unless documented otherwise. Loaders that read shapefiles wrap them in
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
+import cartopy.io.shapereader as shapereader
+from cartopy.feature import ShapelyFeature
 from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
 
@@ -54,3 +58,33 @@ def add_land_water_fill(
         edgecolor="none",
         zorder=1,
     )
+
+
+@lru_cache(maxsize=1)
+def _county_records() -> tuple:
+    """Load Natural Earth admin_2_counties_lakes (10m), cached.
+
+    Returns a tuple of shapely geometries. We strip attributes — we don't
+    need names, populations, or any other metadata to draw outlines.
+    """
+    path = shapereader.natural_earth(
+        category="cultural", name="admin_2_counties_lakes", resolution="10m"
+    )
+    return tuple(record.geometry for record in shapereader.Reader(path).records())
+
+
+def add_counties(ax: Axes) -> None:
+    """Draw US county boundaries as thin gray lines under states.
+
+    Counties shape comes from Natural Earth admin_2_counties_lakes (10m),
+    which excludes lake polygons (so we don't get spurious "county"
+    boundaries cutting through the Great Lakes / Lake Champlain).
+    """
+    feat = ShapelyFeature(
+        _county_records(),
+        ccrs.PlateCarree(),
+        facecolor="none",
+        edgecolor=COUNTY_COLOR,
+        linewidth=0.3,
+    )
+    ax.add_feature(feat, zorder=2)

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -7,6 +7,9 @@ takes the radar axes (and any other context it needs) and mutates it.
 
 from __future__ import annotations
 
+import math
+
+import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
@@ -35,3 +38,36 @@ def add_colorbar(ax: Axes, opts) -> None:
     cb.set_ticks([-20, 0, 20, 40, 60, 75])
     cb.ax.tick_params(labelsize=6, length=2, pad=1)
     cb.set_label("dBZ", fontsize=6, labelpad=1)
+
+
+def add_scale_bar(ax: Axes, length_km: float = 20.0) -> None:
+    """Draw a fixed-length scale bar in the lower-right of the radar axes.
+
+    Length is converted from km to projected coords using the latitude
+    of the axes' center — accurate to within ~1% for any reasonable
+    radar zoom (the projection distortion over 20 km at mid-latitudes
+    is negligible).
+    """
+    west, east, south, north = ax.get_extent(crs=ccrs.PlateCarree())
+    center_lat = (south + north) / 2.0
+    # 1° lon ≈ 111 km · cos(lat); invert for "what fraction of a degree
+    # is `length_km`?".
+    deg_per_km = 1.0 / (111.0 * max(math.cos(math.radians(center_lat)), 1e-6))
+    bar_deg = length_km * deg_per_km
+
+    # Anchor at 5% in from the right edge, 5% up from the bottom.
+    x_end = east - 0.05 * (east - west)
+    x_start = x_end - bar_deg
+    y = south + 0.05 * (north - south)
+
+    ax.plot(
+        [x_start, x_end], [y, y],
+        color="black", linewidth=2,
+        transform=ccrs.PlateCarree(), zorder=10,
+    )
+    ax.text(
+        (x_start + x_end) / 2, y + 0.01 * (north - south),
+        f"{int(length_km)} km",
+        fontsize=7, color="black", ha="center", va="bottom",
+        transform=ccrs.PlateCarree(), zorder=10,
+    )

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -8,21 +8,20 @@ takes the radar axes (and any other context it needs) and mutates it.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-import cartopy.crs as ccrs
+import cartopy.crs as ccrs  # type: ignore[import-untyped]
 import matplotlib.pyplot as plt
-from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from dras_renderer.decode import DecodedScan
     from dras_renderer.render import RenderOptions
 
 
-def add_colorbar(ax: Axes, opts: RenderOptions) -> None:
+def add_colorbar(ax: Any, opts: RenderOptions) -> None:
     """Inset horizontal reflectivity colorbar in the lower-left corner.
 
     Uses the same ``pyart_NWSRef`` cmap and (vmin, vmax) the radar plot
@@ -45,7 +44,7 @@ def add_colorbar(ax: Axes, opts: RenderOptions) -> None:
     cb.set_label("dBZ", fontsize=6, labelpad=1)
 
 
-def add_scale_bar(ax: Axes, length_km: float = 20.0) -> None:
+def add_scale_bar(ax: Any, length_km: float = 20.0) -> None:
     """Draw a fixed-length scale bar in the lower-right of the radar axes.
 
     Length is converted from km to projected coords using the latitude
@@ -78,7 +77,7 @@ def add_scale_bar(ax: Axes, length_km: float = 20.0) -> None:
     )
 
 
-def add_north_arrow(ax: Axes) -> None:
+def add_north_arrow(ax: Any) -> None:
     """Place a small N + upward arrow glyph in the upper-right of the axes.
 
     Uses axes-fraction coords so position is invariant to data extent.
@@ -98,7 +97,7 @@ def add_north_arrow(ax: Axes) -> None:
 
 
 def add_footer(
-    footer_ax: Axes,
+    footer_ax: Any,
     scan: DecodedScan,
     data_age_seconds: float | None,
     renderer_version: str,

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -8,6 +8,7 @@ takes the radar axes (and any other context it needs) and mutates it.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
@@ -16,8 +17,12 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
+if TYPE_CHECKING:
+    from dras_renderer.decode import DecodedScan
+    from dras_renderer.render import RenderOptions
 
-def add_colorbar(ax: Axes, opts) -> None:
+
+def add_colorbar(ax: Axes, opts: RenderOptions) -> None:
     """Inset horizontal reflectivity colorbar in the lower-left corner.
 
     Uses the same ``pyart_NWSRef`` cmap and (vmin, vmax) the radar plot
@@ -94,7 +99,7 @@ def add_north_arrow(ax: Axes) -> None:
 
 def add_footer(
     footer_ax: Axes,
-    scan,  # DecodedScan
+    scan: DecodedScan,
     data_age_seconds: float | None,
     renderer_version: str,
 ) -> None:

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -71,3 +71,22 @@ def add_scale_bar(ax: Axes, length_km: float = 20.0) -> None:
         fontsize=7, color="black", ha="center", va="bottom",
         transform=ccrs.PlateCarree(), zorder=10,
     )
+
+
+def add_north_arrow(ax: Axes) -> None:
+    """Place a small N + upward arrow glyph in the upper-right of the axes.
+
+    Uses axes-fraction coords so position is invariant to data extent.
+    """
+    ax.annotate(
+        "N",
+        xy=(0.95, 0.93),
+        xytext=(0.95, 0.97),
+        xycoords="axes fraction",
+        textcoords="axes fraction",
+        ha="center", va="bottom",
+        fontsize=10, fontweight="bold", color="black",
+        arrowprops=dict(facecolor="black", edgecolor="black",
+                        width=2, headwidth=8, headlength=8),
+        zorder=10,
+    )

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -1,0 +1,37 @@
+"""Cartographic furniture: colorbar, scale bar, N arrow, footer.
+
+Furniture functions add visual elements that are part of the *map*, not
+the data — anything a cartographer would call "marginalia." Each function
+takes the radar axes (and any other context it needs) and mutates it.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+
+
+def add_colorbar(ax: Axes, opts) -> None:
+    """Inset horizontal reflectivity colorbar in the lower-left corner.
+
+    Uses the same ``pyart_NWSRef`` cmap and (vmin, vmax) the radar plot
+    is rendered with so the inset is exactly the active scale.
+    """
+    cax = inset_axes(
+        ax,
+        width="28%", height="3%",
+        loc="lower left",
+        bbox_to_anchor=(0.02, 0.02, 1, 1),
+        bbox_transform=ax.transAxes,
+        borderpad=0,
+    )
+    cax.set_facecolor((1, 1, 1, 0.85))
+    sm = ScalarMappable(norm=Normalize(vmin=opts.vmin, vmax=opts.vmax),
+                        cmap="pyart_NWSRef")
+    cb = plt.colorbar(sm, cax=cax, orientation="horizontal")
+    cb.set_ticks([-20, 0, 20, 40, 60, 75])
+    cb.ax.tick_params(labelsize=6, length=2, pad=1)
+    cb.set_label("dBZ", fontsize=6, labelpad=1)

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -90,3 +90,33 @@ def add_north_arrow(ax: Axes) -> None:
                         width=2, headwidth=8, headlength=8),
         zorder=10,
     )
+
+
+def add_footer(
+    footer_ax: Axes,
+    scan,  # DecodedScan
+    data_age_seconds: float | None,
+    renderer_version: str,
+) -> None:
+    """Render the metadata strip below the radar plot.
+
+    Single line, center-aligned. Format:
+      ``KATX • 0.5° base reflectivity • 2026-05-03 19:12 UTC • age 12s • dras-renderer v9.9.9``
+    """
+    footer_ax.set_facecolor("white")
+    footer_ax.set_xticks([])
+    footer_ax.set_yticks([])
+    for spine in footer_ax.spines.values():
+        spine.set_visible(False)
+
+    age_part = f"age {int(round(data_age_seconds))}s" if data_age_seconds is not None else "age unknown"
+    when = scan.scan_time.strftime("%Y-%m-%d %H:%M UTC")
+    text = (
+        f"{scan.station_id}  •  {scan.elevation_deg:.1f}° base reflectivity  "
+        f"•  {when}  •  {age_part}  •  dras-renderer v{renderer_version}"
+    )
+    footer_ax.text(
+        0.5, 0.5, text,
+        ha="center", va="center", fontsize=8, color="#333",
+        transform=footer_ax.transAxes,
+    )

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -21,7 +21,7 @@ import pyart  # type: ignore[import-untyped]
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from dras_renderer import basemap
+from dras_renderer import basemap, furniture
 from dras_renderer.decode import DecodedScan
 
 
@@ -219,6 +219,9 @@ def _render_figure(
             opts.cities_max_scalerank,
             deconflict=opts.deconflict_labels,
         )
+
+    if opts.show_colorbar:
+        furniture.add_colorbar(ax, opts)
 
     return fig, ax
 

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -182,7 +182,14 @@ def _render_figure(
     if opts.show_counties:
         basemap.add_counties(ax)
 
-    # Basemap layers, drawn from bottom up.
+    # Remaining basemap layers, in the design z-order:
+    # states → roads → coastline → lakes (outlined) → borders.
+    # Lakes come after coastline so their outline isn't cut by the
+    # coastline stroke where they touch the shore.
+    ax.add_feature(cfeature.STATES.with_scale("50m"), edgecolor="gray", linewidth=0.5)
+    if opts.show_roads:
+        basemap.add_roads(ax, extent)
+    ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
     if opts.show_lakes:
         ax.add_feature(
             cfeature.LAKES.with_scale("50m"),
@@ -190,10 +197,6 @@ def _render_figure(
             edgecolor="#4a6da7",
             linewidth=0.4,
         )
-    ax.add_feature(cfeature.STATES.with_scale("50m"), edgecolor="gray", linewidth=0.5)
-    if opts.show_roads:
-        basemap.add_roads(ax, extent)
-    ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
     if opts.show_borders:
         ax.add_feature(
             cfeature.BORDERS.with_scale("50m"),

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -226,6 +226,9 @@ def _render_figure(
     if opts.show_scale_bar:
         furniture.add_scale_bar(ax)
 
+    if opts.show_north_arrow:
+        furniture.add_north_arrow(ax)
+
     return fig, ax
 
 

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -23,6 +23,7 @@ from matplotlib.figure import Figure
 
 from dras_renderer import basemap, furniture
 from dras_renderer.decode import DecodedScan
+from dras_renderer.version import VERSION
 
 
 @dataclass(frozen=True)
@@ -49,7 +50,7 @@ class RenderOptions:
     center_lon: float | None = None
 
     # Clutter filter. Set ``clutter_filter=False`` to disable (renders the
-    # raw Py-ART ouput, useful for QA / debugging).
+    # raw Py-ART output, useful for QA / debugging).
     clutter_filter: bool = True
     # Reflectivity floor in dBZ. Anything weaker is suppressed — kills
     # noise floor + most ground/sea clutter and biota. 15 dBZ is a typical
@@ -246,7 +247,6 @@ def _render_figure(
         furniture.add_north_arrow(ax)
 
     if opts.show_footer and footer_ax is not None:
-        from dras_renderer.version import VERSION
         furniture.add_footer(
             footer_ax, scan, data_age_seconds, renderer_version=VERSION,
         )

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -166,6 +166,9 @@ def _render_figure(
 
     basemap.add_land_water_fill(ax, extent)
 
+    if opts.show_counties:
+        basemap.add_counties(ax)
+
     # Basemap layers, drawn from bottom up.
     if opts.show_lakes:
         ax.add_feature(

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -178,6 +178,8 @@ def _render_figure(
             linewidth=0.4,
         )
     ax.add_feature(cfeature.STATES.with_scale("50m"), edgecolor="gray", linewidth=0.5)
+    if opts.show_roads:
+        basemap.add_roads(ax, extent)
     ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
     if opts.show_borders:
         ax.add_feature(

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import math
 from dataclasses import dataclass
-from functools import lru_cache
 from typing import Any
 
 # Headless backend MUST be selected before importing pyplot. ``matplotlib.use``
@@ -17,7 +16,6 @@ matplotlib.use("Agg")
 
 import cartopy.crs as ccrs  # type: ignore[import-untyped]
 import cartopy.feature as cfeature  # type: ignore[import-untyped]
-import cartopy.io.shapereader as shapereader  # type: ignore[import-untyped]
 import matplotlib.pyplot as plt
 import pyart  # type: ignore[import-untyped]
 from matplotlib.axes import Axes
@@ -215,7 +213,7 @@ def _render_figure(
         )
 
     if opts.show_cities:
-        _add_cities(ax, extent, max_scalerank=opts.cities_max_scalerank)
+        basemap.add_cities(ax, extent, opts.cities_max_scalerank)
 
     return fig, ax
 
@@ -241,65 +239,3 @@ def _build_clutter_filter(radar: Any, opts: RenderOptions) -> Any:
         radar, "reflectivity", gatefilter=gf, size=opts.despeckle_size
     )
     return gf
-
-
-@lru_cache(maxsize=1)
-def _populated_places_records() -> tuple[tuple[float, float, str, int], ...]:
-    """Load Natural Earth populated_places once.
-
-    Returns a tuple of (lon, lat, name, scalerank) tuples. Caching avoids
-    re-reading the shapefile on every render — the file is small but the
-    repeated I/O + shapely geometry construction is wasteful.
-    """
-    path = shapereader.natural_earth(
-        category="cultural", name="populated_places", resolution="10m"
-    )
-    out: list[tuple[float, float, str, int]] = []
-    for record in shapereader.Reader(path).records():
-        attrs = record.attributes
-        name = attrs.get("NAME") or attrs.get("name")
-        if not name:
-            continue
-        # SCALERANK is the Natural Earth "global importance" rank; lower
-        # = more prominent. 10 is the missing/sentinel value.
-        try:
-            scalerank = int(attrs.get("SCALERANK", 99))
-        except (TypeError, ValueError):
-            scalerank = 99
-        geom = record.geometry
-        out.append((float(geom.x), float(geom.y), str(name), scalerank))
-    return tuple(out)
-
-
-def _add_cities(
-    ax: Any, extent: tuple[float, float, float, float], max_scalerank: int
-) -> None:
-    """Plot Natural Earth populated places that lie inside the extent.
-
-    Filters by SCALERANK so dense metros don't drown the map in labels.
-    """
-    west, east, south, north = extent
-    for lon0, lat0, name, scalerank in _populated_places_records():
-        if scalerank > max_scalerank:
-            continue
-        if not (west <= lon0 <= east and south <= lat0 <= north):
-            continue
-        ax.plot(
-            lon0,
-            lat0,
-            "o",
-            markersize=2.5,
-            color="black",
-            transform=ccrs.PlateCarree(),
-            zorder=5,
-        )
-        ax.text(
-            lon0 + 0.04,
-            lat0 + 0.02,
-            name,
-            fontsize=7,
-            color="black",
-            transform=ccrs.PlateCarree(),
-            zorder=5,
-            clip_on=True,
-        )

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -223,6 +223,9 @@ def _render_figure(
     if opts.show_colorbar:
         furniture.add_colorbar(ax, opts)
 
+    if opts.show_scale_bar:
+        furniture.add_scale_bar(ax)
+
     return fig, ax
 
 

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -23,6 +23,7 @@ import pyart  # type: ignore[import-untyped]
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
+from dras_renderer import basemap
 from dras_renderer.decode import DecodedScan
 
 
@@ -162,6 +163,8 @@ def _render_figure(
         center_lat + delta_lat,
     )
     ax.set_extent(extent, crs=ccrs.PlateCarree())
+
+    basemap.add_land_water_fill(ax, extent)
 
     # Basemap layers, drawn from bottom up.
     if opts.show_lakes:

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -132,10 +132,6 @@ def _render_figure(
     axes (title, artists) before the figure is closed. The caller owns the
     returned ``Figure`` and is responsible for calling ``plt.close(fig)``.
     """
-    fig = plt.figure(
-        figsize=(opts.width / opts.dpi, opts.height / opts.dpi),
-        dpi=opts.dpi,
-    )
     radar = scan.radar
     radar_lat = float(radar.latitude["data"][0])
     radar_lon = float(radar.longitude["data"][0])
@@ -147,7 +143,25 @@ def _render_figure(
         central_latitude=center_lat,
         central_longitude=center_lon,
     )
-    ax = fig.add_subplot(1, 1, 1, projection=projection)
+
+    footer_height_frac = 0.08 if opts.show_footer else 0.0
+    footer_px = round(opts.height * footer_height_frac)
+    total_height_px = opts.height + footer_px
+
+    fig = plt.figure(
+        figsize=(opts.width / opts.dpi, total_height_px / opts.dpi),
+        dpi=opts.dpi,
+    )
+
+    # Carve the figure into [radar plot on top, footer strip below].
+    radar_top_frac = opts.height / total_height_px
+    ax = fig.add_axes(
+        (0, 1 - radar_top_frac, 1, radar_top_frac),
+        projection=projection,
+    )
+    footer_ax = (
+        fig.add_axes((0, 0, 1, 1 - radar_top_frac)) if opts.show_footer else None
+    )
 
     # 1° lat ≈ 111 km everywhere; 1° lon ≈ 111 cos(lat) km. Without the
     # cos(lat) correction the east-west extent stretches by 33% at KATX
@@ -206,11 +220,13 @@ def _render_figure(
     # Override Py-ART's default title to surface both the volume start time
     # and the freshest-chunk age — answers "is this image stale?" at a glance.
     # MUST come after plot_ppi_map, which sets its own title via title_flag=True.
-    if data_age_seconds is not None:
+    if data_age_seconds is not None and not opts.show_footer:
         ax.set_title(
             f"{scan.station_id} {scan.elevation_deg:.1f} Deg. "
             f"{scan.scan_time.isoformat()}  +Δ {data_age_seconds:.0f}s"
         )
+    elif opts.show_footer:
+        ax.set_title("")  # suppress Py-ART's auto title
 
     if opts.show_cities:
         basemap.add_cities(
@@ -228,6 +244,12 @@ def _render_figure(
 
     if opts.show_north_arrow:
         furniture.add_north_arrow(ax)
+
+    if opts.show_footer and footer_ax is not None:
+        from dras_renderer.version import VERSION
+        furniture.add_footer(
+            footer_ax, scan, data_age_seconds, renderer_version=VERSION,
+        )
 
     return fig, ax
 

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -155,8 +155,11 @@ def _render_figure(
     )
 
     # Carve the figure into [radar plot on top, footer strip below].
+    # ax is a Cartopy GeoAxes (since projection= is passed) — typed as Any
+    # because mpl stubs return plain Axes from add_axes, which lacks the
+    # GeoAxes-specific set_extent/add_feature methods we need below.
     radar_top_frac = opts.height / total_height_px
-    ax = fig.add_axes(
+    ax: Any = fig.add_axes(
         (0, 1 - radar_top_frac, 1, radar_top_frac),
         projection=projection,
     )

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -213,7 +213,12 @@ def _render_figure(
         )
 
     if opts.show_cities:
-        basemap.add_cities(ax, extent, opts.cities_max_scalerank)
+        basemap.add_cities(
+            ax,
+            extent,
+            opts.cities_max_scalerank,
+            deconflict=opts.deconflict_labels,
+        )
 
     return fig, ax
 

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -79,6 +79,20 @@ class RenderOptions:
     # the Natural Earth maximum — every named populated place.
     cities_max_scalerank: int = 8
 
+    # New basemap layers (Task 4–7).
+    show_counties: bool = True
+    show_roads: bool = True
+
+    # Cartographic furniture (Task 9–12).
+    show_colorbar: bool = True
+    show_scale_bar: bool = True
+    show_north_arrow: bool = True
+    show_footer: bool = True
+
+    # Label deconfliction (Task 8). When False, falls back to the existing
+    # fixed-offset placement with a white text halo.
+    deconflict_labels: bool = True
+
 
 def render_base_reflectivity(
     scan: DecodedScan,

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -29,8 +29,8 @@ from dras_renderer.decode import DecodedScan
 class RenderOptions:
     """Options controlling render output."""
 
-    width: int = 800
-    height: int = 800
+    width: int = 1000
+    height: int = 1000
     # 150 km centers the view on the Puget Sound corridor (radar at Camano
     # Island for KATX) while keeping the inland Cascades and Olympia in
     # frame. The radar's nominal 230 km range zooms out so far that named

--- a/renderer/tests/test_basemap.py
+++ b/renderer/tests/test_basemap.py
@@ -1,0 +1,39 @@
+"""Basemap layer tests."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import pytest
+
+from dras_renderer.basemap import add_land_water_fill
+from dras_renderer.decode import DecodedScan, decode_level2_archive
+
+FIXTURE = Path(__file__).parent / "fixtures" / "KATX_test.ar2v.gz"
+
+
+@pytest.fixture(scope="session")
+def decoded() -> DecodedScan:
+    return decode_level2_archive(gzip.decompress(FIXTURE.read_bytes()))
+
+
+def _make_axes() -> tuple[plt.Figure, plt.Axes]:
+    fig = plt.figure(figsize=(4, 4))
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    ax.set_extent((-123.0, -121.5, 47.0, 48.5), crs=ccrs.PlateCarree())
+    return fig, ax
+
+
+def test_add_land_water_fill_adds_two_features() -> None:
+    """add_land_water_fill paints ocean then masks with land — two features."""
+    fig, ax = _make_axes()
+    try:
+        baseline_features = len(ax._children)
+        add_land_water_fill(ax, extent=(-123.0, -121.5, 47.0, 48.5))
+        added = len(ax._children) - baseline_features
+        assert added >= 2  # one for ocean fill, one for land polygon
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_basemap.py
+++ b/renderer/tests/test_basemap.py
@@ -60,3 +60,28 @@ def test_add_counties_adds_artist() -> None:
         assert len(ax._children) > baseline
     finally:
         plt.close(fig)
+
+
+def test_add_roads_filters_by_class() -> None:
+    """Only Major and Secondary Highway classes are rendered (no local
+    or unclassified roads)."""
+    from dras_renderer.basemap import _road_records
+
+    _road_records.cache_clear()
+    records = _road_records()
+    classes = {cls for _, cls in records}
+    # NE roads dataset uses these top-level types we keep:
+    assert classes <= {"Major Highway", "Secondary Highway", "Beltway", "Bypass"}
+
+
+def test_add_roads_adds_artist_when_extent_contains_roads() -> None:
+    """Calling add_roads over a US metro extent adds at least one feature."""
+    from dras_renderer.basemap import add_roads
+
+    fig, ax = _make_axes()
+    try:
+        baseline = len(ax._children)
+        add_roads(ax, extent=(-123.0, -121.5, 47.0, 48.5))  # KATX metro
+        assert len(ax._children) > baseline
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_basemap.py
+++ b/renderer/tests/test_basemap.py
@@ -37,3 +37,26 @@ def test_add_land_water_fill_adds_two_features() -> None:
         assert added >= 2  # one for ocean fill, one for land polygon
     finally:
         plt.close(fig)
+
+
+def test_add_counties_loads_records_once() -> None:
+    """County records are cached — repeated calls hit the lru_cache."""
+    from dras_renderer.basemap import _county_records, add_counties
+
+    _county_records.cache_clear()
+    add_counties(_make_axes()[1])
+    assert _county_records.cache_info().hits == 0
+    add_counties(_make_axes()[1])
+    assert _county_records.cache_info().hits >= 1
+
+
+def test_add_counties_adds_artist() -> None:
+    from dras_renderer.basemap import add_counties
+
+    fig, ax = _make_axes()
+    try:
+        baseline = len(ax._children)
+        add_counties(ax)
+        assert len(ax._children) > baseline
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_basemap.py
+++ b/renderer/tests/test_basemap.py
@@ -31,9 +31,9 @@ def test_add_land_water_fill_adds_two_features() -> None:
     """add_land_water_fill paints ocean then masks with land — two features."""
     fig, ax = _make_axes()
     try:
-        baseline_features = len(ax._children)
+        baseline_features = len(ax.get_children())
         add_land_water_fill(ax, extent=(-123.0, -121.5, 47.0, 48.5))
-        added = len(ax._children) - baseline_features
+        added = len(ax.get_children()) - baseline_features
         assert added >= 2  # one for ocean fill, one for land polygon
     finally:
         plt.close(fig)
@@ -55,9 +55,9 @@ def test_add_counties_adds_artist() -> None:
 
     fig, ax = _make_axes()
     try:
-        baseline = len(ax._children)
+        baseline = len(ax.get_children())
         add_counties(ax)
-        assert len(ax._children) > baseline
+        assert len(ax.get_children()) > baseline
     finally:
         plt.close(fig)
 
@@ -80,9 +80,9 @@ def test_add_roads_adds_artist_when_extent_contains_roads() -> None:
 
     fig, ax = _make_axes()
     try:
-        baseline = len(ax._children)
+        baseline = len(ax.get_children())
         add_roads(ax, extent=(-123.0, -121.5, 47.0, 48.5))  # KATX metro
-        assert len(ax._children) > baseline
+        assert len(ax.get_children()) > baseline
     finally:
         plt.close(fig)
 

--- a/renderer/tests/test_basemap.py
+++ b/renderer/tests/test_basemap.py
@@ -85,3 +85,54 @@ def test_add_roads_adds_artist_when_extent_contains_roads() -> None:
         assert len(ax._children) > baseline
     finally:
         plt.close(fig)
+
+
+def test_add_cities_deconflict_runs(decoded) -> None:
+    """With deconflict=True, no two visible city label bboxes overlap.
+
+    Render at the KATX metro extent (Bremerton/Seattle/Tacoma cluster)
+    where the un-deconflicted labels visibly stack. Compare bbox pairs
+    in display coords.
+    """
+    import matplotlib.pyplot as plt
+    from dras_renderer.basemap import add_cities
+
+    fig, ax = _make_axes()
+    ax.set_extent((-122.7, -121.9, 47.2, 47.9), crs=ccrs.PlateCarree())
+    try:
+        add_cities(ax, extent=(-122.7, -121.9, 47.2, 47.9), max_scalerank=8,
+                   deconflict=True)
+        fig.canvas.draw()  # adjustText needs a canvas to compute bboxes
+
+        labels = [c for c in ax.texts if c.get_text()]
+        assert len(labels) >= 2
+        renderer = fig.canvas.get_renderer()
+        bboxes = [t.get_window_extent(renderer=renderer) for t in labels]
+        for i in range(len(bboxes)):
+            for j in range(i + 1, len(bboxes)):
+                # overlaps returns True if the bboxes touch or overlap.
+                assert not bboxes[i].overlaps(bboxes[j]), (
+                    f"labels {labels[i].get_text()!r} and "
+                    f"{labels[j].get_text()!r} overlap after deconfliction"
+                )
+    finally:
+        plt.close(fig)
+
+
+def test_add_cities_label_has_white_halo() -> None:
+    """Every city label has a white path_effects stroke for legibility."""
+    from matplotlib.patheffects import withStroke
+    from dras_renderer.basemap import add_cities
+
+    fig, ax = _make_axes()
+    try:
+        add_cities(ax, extent=(-123.0, -121.5, 47.0, 48.5), max_scalerank=8,
+                   deconflict=False)
+        for t in ax.texts:
+            effects = t.get_path_effects()
+            assert effects, f"label {t.get_text()!r} has no path effects"
+            kinds = {type(e).__name__ for e in effects}
+            assert "withStroke" in kinds or any(isinstance(e, withStroke)
+                                                for e in effects)
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_furniture.py
+++ b/renderer/tests/test_furniture.py
@@ -50,3 +50,16 @@ def test_add_scale_bar_adds_text_and_line() -> None:
         assert any("20 km" in lab for lab in labels)
     finally:
         plt.close(fig)
+
+
+def test_add_north_arrow_adds_n_label() -> None:
+    """N arrow adds an 'N' text label."""
+    from dras_renderer.furniture import add_north_arrow
+
+    fig, ax = _make_axes()
+    try:
+        add_north_arrow(ax)
+        labels = [t.get_text() for t in ax.texts]
+        assert "N" in labels
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_furniture.py
+++ b/renderer/tests/test_furniture.py
@@ -1,0 +1,39 @@
+"""Tests for cartographic furniture (colorbar, scale bar, N arrow, footer)."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import pytest
+
+from dras_renderer.decode import DecodedScan, decode_level2_archive
+from dras_renderer.furniture import add_colorbar
+from dras_renderer.render import RenderOptions
+
+FIXTURE = Path(__file__).parent / "fixtures" / "KATX_test.ar2v.gz"
+
+
+@pytest.fixture(scope="session")
+def decoded() -> DecodedScan:
+    return decode_level2_archive(gzip.decompress(FIXTURE.read_bytes()))
+
+
+def _make_axes() -> tuple[plt.Figure, plt.Axes]:
+    fig = plt.figure(figsize=(4, 4))
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    ax.set_extent((-123.0, -121.5, 47.0, 48.5), crs=ccrs.PlateCarree())
+    return fig, ax
+
+
+def test_add_colorbar_creates_inset_axes() -> None:
+    """add_colorbar creates a new inset axes inside the parent figure."""
+    fig, ax = _make_axes()
+    try:
+        before = len(fig.axes)
+        add_colorbar(ax, RenderOptions())
+        assert len(fig.axes) == before + 1
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_furniture.py
+++ b/renderer/tests/test_furniture.py
@@ -63,3 +63,22 @@ def test_add_north_arrow_adds_n_label() -> None:
         assert "N" in labels
     finally:
         plt.close(fig)
+
+
+def test_add_footer_text_includes_station_and_age(decoded) -> None:
+    """Footer text mentions station, scan time, and data-age annotation."""
+    from dras_renderer.furniture import add_footer
+
+    fig = plt.figure(figsize=(8, 8.6))
+    radar_ax = fig.add_axes((0, 0.08, 1, 0.92))
+    footer_ax = fig.add_axes((0, 0, 1, 0.08))
+
+    try:
+        add_footer(footer_ax, decoded, data_age_seconds=12.0,
+                   renderer_version="9.9.9")
+        labels = " ".join(t.get_text() for t in footer_ax.texts)
+        assert decoded.station_id in labels
+        assert "9.9.9" in labels
+        assert "12s" in labels
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_furniture.py
+++ b/renderer/tests/test_furniture.py
@@ -37,3 +37,16 @@ def test_add_colorbar_creates_inset_axes() -> None:
         assert len(fig.axes) == before + 1
     finally:
         plt.close(fig)
+
+
+def test_add_scale_bar_adds_text_and_line() -> None:
+    """Scale bar adds at least one Line2D and one Text artist with '20 km'."""
+    from dras_renderer.furniture import add_scale_bar
+
+    fig, ax = _make_axes()
+    try:
+        add_scale_bar(ax, length_km=20)
+        labels = [t.get_text() for t in ax.texts]
+        assert any("20 km" in lab for lab in labels)
+    finally:
+        plt.close(fig)

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -117,3 +117,15 @@ def test_matplotlib_uses_agg_backend() -> None:
     import dras_renderer.render  # noqa: F401
 
     assert matplotlib.get_backend().lower() == "agg"
+
+
+def test_render_options_has_new_layer_toggles() -> None:
+    """All new visual layers default to on; can be flipped off independently."""
+    opts = RenderOptions()
+    assert opts.show_counties is True
+    assert opts.show_roads is True
+    assert opts.show_colorbar is True
+    assert opts.show_scale_bar is True
+    assert opts.show_north_arrow is True
+    assert opts.show_footer is True
+    assert opts.deconflict_labels is True

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -30,11 +30,21 @@ def test_render_returns_png_bytes(decoded: DecodedScan) -> None:
     assert png.startswith(b"\x89PNG")
 
 
-def test_render_dimensions_match_options(decoded: DecodedScan) -> None:
-    opts = RenderOptions(width=400, height=400)
+def test_render_dimensions_match_options_no_footer(decoded: DecodedScan) -> None:
+    """Without the footer, the PNG matches (width, height) exactly."""
+    opts = RenderOptions(width=400, height=400, show_footer=False)
     png = render_base_reflectivity(decoded, opts)
     img = Image.open(io.BytesIO(png))
     assert img.size == (400, 400)
+
+
+def test_render_dimensions_grow_for_footer(decoded: DecodedScan) -> None:
+    """With the footer, the PNG height = requested height + 8% strip."""
+    opts = RenderOptions(width=400, height=400, show_footer=True)
+    png = render_base_reflectivity(decoded, opts)
+    img = Image.open(io.BytesIO(png))
+    assert img.size[0] == 400
+    assert img.size[1] == 400 + round(400 * 0.08)
 
 
 def test_render_respects_range_km(decoded: DecodedScan) -> None:
@@ -76,7 +86,7 @@ def test_render_title_includes_scan_time_and_data_age(decoded: DecodedScan) -> N
 
     Uses 30.0 to dodge banker's-rounding ambiguity on .5 values.
     """
-    fig, ax = _render_figure(decoded, RenderOptions(), data_age_seconds=30.0)
+    fig, ax = _render_figure(decoded, RenderOptions(show_footer=False), data_age_seconds=30.0)
     try:
         title = ax.get_title()
     finally:
@@ -94,7 +104,7 @@ def test_render_default_title_unchanged_when_no_age(decoded: DecodedScan) -> Non
     don't pin the exact text (locks us to a Py-ART version), but assert
     it's non-empty and lacks the "+Δ" annotation.
     """
-    fig, ax = _render_figure(decoded, RenderOptions(), data_age_seconds=None)
+    fig, ax = _render_figure(decoded, RenderOptions(show_footer=False), data_age_seconds=None)
     try:
         title = ax.get_title()
     finally:

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -139,3 +139,14 @@ def test_render_options_has_new_layer_toggles() -> None:
     assert opts.show_north_arrow is True
     assert opts.show_footer is True
     assert opts.deconflict_labels is True
+
+
+def test_render_options_defaults_match_route_defaults() -> None:
+    """RenderOptions().width/.height must match the FastAPI route's
+    Query(...) defaults (1000×1000) so direct library use produces the
+    same dimensions as the HTTP API. Prior drift here gave library
+    callers an 800x864 PNG while the route produced 1000x1080.
+    """
+    opts = RenderOptions()
+    assert opts.width == 1000
+    assert opts.height == 1000

--- a/renderer/tests/test_render_route.py
+++ b/renderer/tests/test_render_route.py
@@ -187,3 +187,21 @@ def test_render_route_lowercases_station(fixture_bytes: bytes) -> None:
 
     assert resp.status_code == 200
     assert captured["station"] == "KATX"
+
+
+def test_render_default_dimensions_are_1000(fixture_bytes: bytes) -> None:
+    """Default render returns a 1000-px-wide image (height grows with footer)."""
+    import io
+
+    from PIL import Image
+
+    with patch("dras_renderer.s3.S3Client.latest_volume", return_value=_vol()), \
+         patch("dras_renderer.s3.S3Client.download_volume", return_value=fixture_bytes):
+        client = TestClient(build_app())
+        resp = client.get("/render/KATX")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    img = Image.open(io.BytesIO(base64.b64decode(payload["image"])))
+    assert img.size[0] == 1000  # width
+    assert img.size[1] >= 1000  # height (>= 1000; footer adds extra later)

--- a/renderer/uv.lock
+++ b/renderer/uv.lock
@@ -9,6 +9,20 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "adjusttext"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d4/6585f3b6fdb75648bca294664af4becc8aa2fb3fb08f4e4e9fd27e10d773/adjusttext-1.3.0.tar.gz", hash = "sha256:4ab75cd4453af4828876ac3e964f2c49be642ea834f0c1f7449558d5f12cbca1", size = 15724, upload-time = "2024-10-31T16:45:36.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/1c/8feedd607cc14c5df9aef74fe3af9a99bf660743b842a9b5b1865326b4aa/adjustText-1.3.0-py3-none-any.whl", hash = "sha256:da23d7b24b6db5ffa039bb136bfa556207365e32f48ac74b07ad26dd485bc691", size = 13154, upload-time = "2024-10-31T16:45:35.227Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +341,7 @@ name = "dras-renderer"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "adjusttext" },
     { name = "arm-pyart" },
     { name = "boto3" },
     { name = "botocore" },
@@ -354,6 +369,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adjusttext", specifier = ">=1.2,<2" },
     { name = "arm-pyart", specifier = ">=1.18,<2" },
     { name = "boto3", specifier = ">=1.35,<2" },
     { name = "botocore", specifier = ">=1.35,<2" },


### PR DESCRIPTION
## Summary

Brings the renderer's default PNG output to visual parity with (and beyond) the NWS RIDGE image.

- **Basemap:** cream land (`#f5f0e6`) on light blue water (`#cfe6f3`), county boundaries, Natural Earth highways (interstates dull-red, secondaries gray, both class- and extent-filtered).
- **Labels:** city labels deconflicted with `adjustText` and given a white halo (`path_effects.withStroke`) for legibility over reflectivity colors. Falls back to halo-only on `adjustText` failure with a WARN log.
- **Furniture:** inset reflectivity colorbar (lower-left), 20 km scale bar (lower-right, lat-corrected), N arrow (upper-right), single-line footer strip (station / elevation / scan time / age / version).
- **Layout:** default size bumped 800×800 → 1000×1000. Footer is additive — total PNG is `(width, height + round(height * 0.08))`, e.g. 1000×1080 at the new default. Documented in the OpenAPI `height` description.
- **Code structure:** `render.py` is orchestration only; basemap layers live in new `basemap.py`, cartographic furniture in new `furniture.py`. `RenderOptions` gains seven new toggles (all default `True`).
- **Deps:** one new — `adjustText>=1.2,<2`. No new data assets; all shapefiles ship with Cartopy's Natural Earth 10m bundle.
- **Docs:** README gains a \"View presets\" section (`view=metro` + how to add new presets).

## Architecture

```
_render_figure(scan, opts, data_age_seconds):
    fig, ax, footer_ax = _build_figure(opts)             # grows fig height when show_footer
    extent = _compute_extent(scan, opts)
    ax.set_extent(extent, crs=ccrs.PlateCarree())

    basemap.add_land_water_fill(ax, extent)
    if opts.show_counties: basemap.add_counties(ax)
    # states → roads → coastline → lakes → borders (per design z-order)
    _plot_reflectivity(ax, scan, opts)                   # existing Py-ART path
    if opts.show_cities:
        basemap.add_cities(ax, extent, opts.cities_max_scalerank,
                           deconflict=opts.deconflict_labels)
    if opts.show_colorbar:    furniture.add_colorbar(ax, opts)
    if opts.show_scale_bar:   furniture.add_scale_bar(ax)
    if opts.show_north_arrow: furniture.add_north_arrow(ax)
    if opts.show_footer:      furniture.add_footer(footer_ax, scan, ...)
```

## Test plan

- [x] `uv run pytest -q` (67 passed, was 52 on main)
- [x] Render a default KATX PNG; verify dims = 1000×1080 and footer/colorbar/scale/N arrow are visible
- [x] Render with `show_footer=False`; verify dims = 1000×1000 and Py-ART title is preserved on the data-age path
- [x] Verify `RenderOptions().width == 1000 and .height == 1000` matches the FastAPI route's `Query(...)` defaults
- [x] Verify `OpenAPI` height description documents the footer-additive contract
- [ ] Spot-check a metro view (`?view=metro`) for label deconfliction in the Bremerton/Seattle/Tacoma cluster

## Code review

Independent code review surfaced one material finding (RenderOptions dataclass defaults still 800×800 — fixed in `ca646e7`) plus cosmetics, all of which were addressed in three follow-up refactor commits.

## Follow-up issues filed

- #113 hypsometric / shaded-relief land treatment
- #114 replace Natural Earth roads with US OSM extract
- #115 NWS warning polygon overlay
- #116 range rings + radar marker
- #117 auto-suburb tier at metro zoom
- #118 deconflict city labels against furniture (colorbar/scale/N arrow)

Plan documents (gitignored): `docs/plans/2026-05-03-renderer-visual-upgrade-{design,implementation}.md`.