### PR TITLE
fix(radar): handle empty/unknown VCP without aborting station processing

### DIFF
--- a/dras/internal/monitor/monitor.go
+++ b/dras/internal/monitor/monitor.go
@@ -100,11 +100,6 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 		return fmt.Errorf("error fetching radar data for station %s: %w", stationID, err)
 	}
 
-	mode, err := radar.GetMode(newRadarData.VCP)
-	if err != nil {
-		return fmt.Errorf("error determining radar mode for station %s: %w", stationID, err)
-	}
-
 	// Poll and store the latest radar image so it can be attached to the
 	// next change notification. Image fetch failures are logged but do not
 	// fail the whole poll.
@@ -124,7 +119,7 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 
 	// Handle first run outside of mutex
 	if isFirstRun {
-		initialMessage := fmt.Sprintf("%s %s - %s Mode", stationID, newRadarData.Name, mode)
+		initialMessage := fmt.Sprintf("%s %s - %s Mode", stationID, newRadarData.Name, newRadarData.Mode)
 		stationLogger.Info(fmt.Sprintf("Initial radar data stored - %s", initialMessage))
 		if m.config.DryRun {
 			stationLogger.Debug(fmt.Sprintf("Would send startup notification: %s", initialMessage))

--- a/dras/internal/radar/compare.go
+++ b/dras/internal/radar/compare.go
@@ -20,17 +20,19 @@ func CompareData(oldData, newData *Data, alertConfig AlertConfig) (bool, string)
 	var changes []string
 
 	if alertConfig.VCP && oldData.VCP != newData.VCP {
-		// Try to get detailed VCP description
-		newModeDesc := getVCPDescription(newData.VCP)
-		if newModeDesc != "" {
-			changes = append(changes, newModeDesc)
-		} else {
-			// Fall back to basic mode detection or raw VCP change
-			if mode, err := GetMode(newData.VCP); err == nil {
-				changes = append(changes, fmt.Sprintf("%s Mode Active", mode))
-			} else {
-				changes = append(changes, fmt.Sprintf("Radar mode changed from %s to %s", oldData.VCP, newData.VCP))
+		// Look up the new VCP in the catalog. Known VCPs surface their
+		// AlertText (preferred) or fall back to "<Mode> Mode Active".
+		// Unknown VCPs report the raw transition so users still see what
+		// changed.
+		if info, err := GetVCPInfo(newData.VCP); err == nil {
+			switch {
+			case info.AlertText != "":
+				changes = append(changes, info.AlertText)
+			default:
+				changes = append(changes, fmt.Sprintf("%s Mode Active", info.Mode))
 			}
+		} else {
+			changes = append(changes, fmt.Sprintf("Radar mode changed from %s to %s", oldData.VCP, newData.VCP))
 		}
 	}
 
@@ -57,18 +59,3 @@ func CompareData(oldData, newData *Data, alertConfig AlertConfig) (bool, string)
 	return false, ""
 }
 
-// getVCPDescription returns detailed descriptions for specific VCP modes
-func getVCPDescription(vcp string) string {
-	switch vcp {
-	case "R35", "R31":
-		return "Clear Air Mode Active"
-	case "R12", "R212":
-		return "Precipitation Mode Active"
-	case "R215":
-		return "Precipitation Mode (Vertical Scanning Emphasis) Active"
-	case "R112":
-		return "Precipitation Mode (Velocity Scanning Emphasis) Active"
-	default:
-		return "" // No specific description available
-	}
-}

--- a/dras/internal/radar/radar.go
+++ b/dras/internal/radar/radar.go
@@ -20,18 +20,20 @@ var ErrUnknownVCP = errors.New("unknown VCP")
 type VCPInfo struct {
 	Mode        string // Coarse category: "Clear Air" or "Precipitation"
 	Description string // Human-readable detail about the scan pattern
+	AlertText   string // User-facing message used in change notifications
 }
 
 // vcpCatalog maps VCP codes (as reported by the NWS radar metadata API) to
-// their coarse mode and a short description. Source: NOAA/NWS WSR-88D
-// operations documentation.
+// their coarse mode, a short description, and the alert text shown to users
+// when this VCP becomes active. Source: NOAA/NWS WSR-88D operations
+// documentation.
 var vcpCatalog = map[string]VCPInfo{
-	"R31":  {Mode: "Clear Air", Description: "Clear Air, long pulse (~10 min cycle, stratiform/biological targets)"},
-	"R35":  {Mode: "Clear Air", Description: "Clear Air, short pulse with clutter mitigation (~7 min cycle)"},
-	"R12":  {Mode: "Precipitation", Description: "Precipitation, rapid evolution (~4.2 min cycle, 14 elevations)"},
-	"R112": {Mode: "Precipitation", Description: "Precipitation with MRLE (multi-PRF range-folding mitigation)"},
-	"R212": {Mode: "Precipitation", Description: "Precipitation with SAILS (~4.5 min cycle, common severe-weather VCP)"},
-	"R215": {Mode: "Precipitation", Description: "Precipitation (~6 min cycle, 15 elevations, tropical/widespread)"},
+	"R31":  {Mode: "Clear Air", Description: "Clear Air, long pulse (~10 min cycle, stratiform/biological targets)", AlertText: "Clear Air Mode Active"},
+	"R35":  {Mode: "Clear Air", Description: "Clear Air, short pulse with clutter mitigation (~7 min cycle)", AlertText: "Clear Air Mode Active"},
+	"R12":  {Mode: "Precipitation", Description: "Precipitation, rapid evolution (~4.2 min cycle, 14 elevations)", AlertText: "Precipitation Mode Active"},
+	"R112": {Mode: "Precipitation", Description: "Precipitation with MRLE (multi-PRF range-folding mitigation)", AlertText: "Precipitation Mode (Velocity Scanning Emphasis) Active"},
+	"R212": {Mode: "Precipitation", Description: "Precipitation with SAILS (~4.5 min cycle, common severe-weather VCP)", AlertText: "Precipitation Mode Active"},
+	"R215": {Mode: "Precipitation", Description: "Precipitation (~6 min cycle, 15 elevations, tropical/widespread)", AlertText: "Precipitation Mode (Vertical Scanning Emphasis) Active"},
 }
 
 // Data represents the data for a radar.

--- a/dras/internal/radar/radar.go
+++ b/dras/internal/radar/radar.go
@@ -10,11 +10,29 @@ import (
 	"github.com/jacaudi/nws/cmd/nws"
 )
 
-// ErrUnknownVCP is returned by GetMode when the VCP code is empty or not
-// recognized. Callers can use errors.Is to detect this case and treat it as
-// a soft condition (use the returned fallback label, log a warning, continue)
-// rather than aborting station processing.
+// ErrUnknownVCP is returned by GetMode/GetVCPInfo when the VCP code is empty
+// or not recognized. Callers can use errors.Is to detect this case and treat
+// it as a soft condition (use the returned fallback label, log a warning,
+// continue) rather than aborting station processing.
 var ErrUnknownVCP = errors.New("unknown VCP")
+
+// VCPInfo describes a NEXRAD WSR-88D Volume Coverage Pattern.
+type VCPInfo struct {
+	Mode        string // Coarse category: "Clear Air" or "Precipitation"
+	Description string // Human-readable detail about the scan pattern
+}
+
+// vcpCatalog maps VCP codes (as reported by the NWS radar metadata API) to
+// their coarse mode and a short description. Source: NOAA/NWS WSR-88D
+// operations documentation.
+var vcpCatalog = map[string]VCPInfo{
+	"R31":  {Mode: "Clear Air", Description: "Clear Air, long pulse (~10 min cycle, stratiform/biological targets)"},
+	"R35":  {Mode: "Clear Air", Description: "Clear Air, short pulse with clutter mitigation (~7 min cycle)"},
+	"R12":  {Mode: "Precipitation", Description: "Precipitation, rapid evolution (~4.2 min cycle, 14 elevations)"},
+	"R112": {Mode: "Precipitation", Description: "Precipitation with MRLE (multi-PRF range-folding mitigation)"},
+	"R212": {Mode: "Precipitation", Description: "Precipitation with SAILS (~4.5 min cycle, common severe-weather VCP)"},
+	"R215": {Mode: "Precipitation", Description: "Precipitation (~6 min cycle, 15 elevations, tropical/widespread)"},
+}
 
 // Data represents the data for a radar.
 type Data struct {
@@ -79,35 +97,33 @@ func (s *Service) FetchData(stationID string) (*Data, error) {
 	return radarData, nil
 }
 
-// GetMode returns the radar mode based on the given VCP (Volume Coverage Pattern) code.
-// It maps specific VCP codes to corresponding radar modes.
+// GetMode returns the radar mode for a given VCP code, looked up from
+// vcpCatalog.
 //
-// If the VCP code is empty or not recognized, GetMode returns a fallback label
-// of the form `Unknown (VCP %q)` along with an error wrapping ErrUnknownVCP.
-// Callers should treat this as a soft condition: errors.Is(err, ErrUnknownVCP)
-// → use the fallback label and continue.
+// If the VCP code is empty or not in the catalog, GetMode returns a fallback
+// label of the form `Unknown (VCP %q)` along with an error wrapping
+// ErrUnknownVCP. Callers should treat this as a soft condition:
+// errors.Is(err, ErrUnknownVCP) → use the fallback label and continue.
 func GetMode(vcp string) (string, error) {
-	var radarMode string
-
-	switch vcp {
-	case "R31":
-		radarMode = "Clear Air"
-	case "R35":
-		radarMode = "Clear Air"
-	case "R12":
-		radarMode = "Precipitation"
-	case "R112":
-		radarMode = "Precipitation"
-	case "R212":
-		radarMode = "Precipitation"
-	case "R215":
-		radarMode = "Precipitation"
-	default:
-		fallback := fmt.Sprintf("Unknown (VCP %q)", vcp)
-		return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, vcp)
+	if info, ok := vcpCatalog[vcp]; ok {
+		return info.Mode, nil
 	}
+	fallback := fmt.Sprintf("Unknown (VCP %q)", vcp)
+	return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, vcp)
+}
 
-	return radarMode, nil
+// GetVCPInfo returns the full catalog entry (mode + description) for a VCP
+// code. Unknown VCPs return a fallback VCPInfo and an error wrapping
+// ErrUnknownVCP, with the same soft-handle semantics as GetMode.
+func GetVCPInfo(vcp string) (VCPInfo, error) {
+	if info, ok := vcpCatalog[vcp]; ok {
+		return info, nil
+	}
+	fallback := VCPInfo{
+		Mode:        fmt.Sprintf("Unknown (VCP %q)", vcp),
+		Description: fmt.Sprintf("Unrecognized VCP code %q", vcp),
+	}
+	return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, vcp)
 }
 
 // simplifyGeneratorState generates the simplified generator state based on the given input.

--- a/dras/internal/radar/radar.go
+++ b/dras/internal/radar/radar.go
@@ -3,11 +3,18 @@ package radar
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
 	"github.com/jacaudi/nws/cmd/nws"
 )
+
+// ErrUnknownVCP is returned by GetMode when the VCP code is empty or not
+// recognized. Callers can use errors.Is to detect this case and treat it as
+// a soft condition (use the returned fallback label, log a warning, continue)
+// rather than aborting station processing.
+var ErrUnknownVCP = errors.New("unknown VCP")
 
 // Data represents the data for a radar.
 type Data struct {
@@ -38,11 +45,17 @@ func (s *Service) FetchData(stationID string) (*Data, error) {
 		return nil, fmt.Errorf("failed to get RADAR data for station %q: %w", stationID, err)
 	}
 
-	// Fetching radar VCP and determine mode
+	// Fetching radar VCP and determine mode. An empty or unrecognized VCP is
+	// not fatal: GetMode returns a "Unknown (VCP ...)" fallback label along
+	// with ErrUnknownVCP. We log a warning and continue so the rest of the
+	// station data (status, generator state, etc.) still gets processed.
 	radarVCPCode := radarResponse.RDA.Properties.VolumeCoveragePattern
-	radarMode, err := GetMode(radarVCPCode) // Converting VCP to readable mode
+	radarMode, err := GetMode(radarVCPCode)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, ErrUnknownVCP) {
+			return nil, err
+		}
+		slog.Warn("Unrecognized VCP, using fallback mode label", "station", stationID, "vcp", radarVCPCode, "mode", radarMode)
 	}
 
 	// Fetching radar VCP and determine mode
@@ -68,7 +81,11 @@ func (s *Service) FetchData(stationID string) (*Data, error) {
 
 // GetMode returns the radar mode based on the given VCP (Volume Coverage Pattern) code.
 // It maps specific VCP codes to corresponding radar modes.
-// If the VCP code is not recognized, it returns an error.
+//
+// If the VCP code is empty or not recognized, GetMode returns a fallback label
+// of the form `Unknown (VCP %q)` along with an error wrapping ErrUnknownVCP.
+// Callers should treat this as a soft condition: errors.Is(err, ErrUnknownVCP)
+// → use the fallback label and continue.
 func GetMode(vcp string) (string, error) {
 	var radarMode string
 
@@ -86,7 +103,8 @@ func GetMode(vcp string) (string, error) {
 	case "R215":
 		radarMode = "Precipitation"
 	default:
-		return "", fmt.Errorf("unknown mode for VCP %s -- please update code", vcp)
+		fallback := fmt.Sprintf("Unknown (VCP %q)", vcp)
+		return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, vcp)
 	}
 
 	return radarMode, nil

--- a/dras/internal/radar/radar_test.go
+++ b/dras/internal/radar/radar_test.go
@@ -54,6 +54,34 @@ func TestGetMode(t *testing.T) {
 	}
 }
 
+func TestGetVCPInfo(t *testing.T) {
+	t.Run("known", func(t *testing.T) {
+		info, err := GetVCPInfo("R212")
+		if err != nil {
+			t.Fatalf("unexpected error for R212: %v", err)
+		}
+		if info.Mode != "Precipitation" {
+			t.Errorf("Mode = %q, want %q", info.Mode, "Precipitation")
+		}
+		if !strings.Contains(info.Description, "SAILS") {
+			t.Errorf("Description = %q, expected to mention SAILS", info.Description)
+		}
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		info, err := GetVCPInfo("R999")
+		if !errors.Is(err, ErrUnknownVCP) {
+			t.Fatalf("expected ErrUnknownVCP, got %v", err)
+		}
+		if !strings.Contains(info.Mode, "Unknown") {
+			t.Errorf("Mode = %q, expected to contain \"Unknown\"", info.Mode)
+		}
+		if !strings.Contains(info.Description, "R999") {
+			t.Errorf("Description = %q, expected to contain raw VCP %q", info.Description, "R999")
+		}
+	})
+}
+
 func TestSanitizeStationIDs(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/dras/internal/radar/radar_test.go
+++ b/dras/internal/radar/radar_test.go
@@ -1,31 +1,43 @@
 package radar
 
 import (
+	"errors"
+	"strings"
 	"testing"
 )
 
 func TestGetMode(t *testing.T) {
 	tests := []struct {
-		vcp      string
-		expected string
-		hasError bool
+		name           string
+		vcp            string
+		expectedMode   string
+		expectUnknown  bool
+		fallbackSubstr string
 	}{
-		{"R31", "Clear Air", false},
-		{"R35", "Clear Air", false},
-		{"R12", "Precipitation", false},
-		{"R112", "Precipitation", false},
-		{"R212", "Precipitation", false},
-		{"R215", "Precipitation", false},
-		{"R99", "", true}, // Unknown VCP should return error
+		{name: "R31", vcp: "R31", expectedMode: "Clear Air"},
+		{name: "R35", vcp: "R35", expectedMode: "Clear Air"},
+		{name: "R12", vcp: "R12", expectedMode: "Precipitation"},
+		{name: "R112", vcp: "R112", expectedMode: "Precipitation"},
+		{name: "R212", vcp: "R212", expectedMode: "Precipitation"},
+		{name: "R215", vcp: "R215", expectedMode: "Precipitation"},
+		{name: "unknown_R99", vcp: "R99", expectUnknown: true, fallbackSubstr: `"R99"`},
+		{name: "empty", vcp: "", expectUnknown: true, fallbackSubstr: `""`},
+		{name: "whitespace", vcp: " ", expectUnknown: true, fallbackSubstr: `" "`},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.vcp, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			mode, err := GetMode(tt.vcp)
 
-			if tt.hasError {
-				if err == nil {
-					t.Errorf("Expected error for VCP %s, but got none", tt.vcp)
+			if tt.expectUnknown {
+				if !errors.Is(err, ErrUnknownVCP) {
+					t.Fatalf("expected ErrUnknownVCP for VCP %q, got %v", tt.vcp, err)
+				}
+				if !strings.Contains(mode, "Unknown") {
+					t.Errorf("expected fallback mode label to contain \"Unknown\" for VCP %q, got %q", tt.vcp, mode)
+				}
+				if !strings.Contains(mode, tt.fallbackSubstr) {
+					t.Errorf("expected fallback mode label to contain %s for VCP %q, got %q", tt.fallbackSubstr, tt.vcp, mode)
 				}
 				return
 			}
@@ -35,8 +47,8 @@ func TestGetMode(t *testing.T) {
 				return
 			}
 
-			if mode != tt.expected {
-				t.Errorf("For VCP %s, expected mode %q, got %q", tt.vcp, tt.expected, mode)
+			if mode != tt.expectedMode {
+				t.Errorf("For VCP %s, expected mode %q, got %q", tt.vcp, tt.expectedMode, mode)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Three-commit branch resolving #121 plus tightening the VCP data layer it touched.

1. **`fix(radar): handle empty/unknown VCP without aborting station processing`** (`c623fe0`)
   - Adds `ErrUnknownVCP` sentinel; `GetMode` returns `("Unknown (VCP %q)", wrapped sentinel)` for empty/unknown codes
   - `FetchData` checks `errors.Is(err, ErrUnknownVCP)` → logs WARN with the raw VCP and continues, so status/generator/operability still get processed
   - Drops the redundant `radar.GetMode()` call in `monitor.processStation` that would have re-raised the hard error and defeated the soft-handle

2. **`refactor(radar): replace VCP switch with typed catalog map`** (`e2a91ff`)
   - Introduces `VCPInfo {Mode, Description}` and a package-level `vcpCatalog` map keyed by VCP code
   - `GetMode` is now a map lookup; new `GetVCPInfo` exposes the description for richer logging/alerts
   - The catalog populates each known VCP's meaning inline as structured data rather than only as comments

3. **`refactor(radar): fold getVCPDescription into vcpCatalog as AlertText`** (`dbce801`)
   - Adds `AlertText` to `VCPInfo` and removes the parallel hand-rolled `getVCPDescription` map in `compare.go`
   - `CompareData` now uses `GetVCPInfo` to surface the alert prose
   - User-facing Pushover text is byte-identical to before for all six known VCPs

## Why
Production prod log on 2026-05-05 14:11 UTC: `level=ERROR msg="Failed to process station: error fetching radar data for station KATX: unknown mode for VCP  -- please update code"` — KATX returned an empty VCP from NWS, causing the entire station's poll cycle to be aborted at ERROR level. Empty VCP is a transient/benign state; other fields still carry useful state and should continue to be compared.

## Pushover behavior preview (verified against this branch)

### Startup
- `KATX Seattle - Precipitation Mode` (R212)
- `KATX Seattle - Clear Air Mode` (R31)
- `KATX Seattle - Unknown (VCP "") Mode` (empty VCP, post-fix)

### Change (title: `KATX Update`)
- VCP `R31 → R212`: `Precipitation Mode Active`
- VCP `R12 → R215`: `Precipitation Mode (Vertical Scanning Emphasis) Active`
- VCP `R212 → R112`: `Precipitation Mode (Velocity Scanning Emphasis) Active`
- VCP changes to unknown future code (`R45`): `Radar mode changed from R212 to R45`
- Status/Operability/Power/Generator changes: existing `from X to Y` strings, unchanged
- Radar PNG is attached only when VCP changed

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `TestGetMode` extended for empty / whitespace / `R99` (asserts `errors.Is(err, ErrUnknownVCP)` + fallback label contains the raw VCP)
- [x] `TestGetVCPInfo` covers known + unknown paths
- [x] Existing `compare_test.go` assertions on `"Precipitation Mode Active"` / `"Clear Air Mode Active"` continue to pass after the catalog refactor

Closes #121