### PR TITLE
feat(renderer): cartographic upgrades — peaks, inland lakes, scope marker, refined colorbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ __pycache__/
 .ruff_cache/
 .mypy_cache/
 *.egg-info/
+.scratch/

--- a/renderer/scripts/cartopy_cache.py
+++ b/renderer/scripts/cartopy_cache.py
@@ -30,8 +30,20 @@ import cartopy.io.shapereader as shp  # type: ignore[import-untyped]
 # render.py — adding a layer there without warming it here means first
 # render in production downloads it, which on read-only/uid-mismatch
 # pods fails outright.
-_PHYSICAL_50M = ("STATES", "COASTLINE", "LAKES", "BORDERS")
+_PHYSICAL_50M = ("STATES", "COASTLINE", "BORDERS")
+# 10m physical features used by basemap. LAND backs the high-res land
+# mask in add_land_water_fill; LAKES needs 10m resolution because 50m
+# drops every inland lake smaller than a Great Lake (e.g. Lake
+# Washington vanishes at 50m).
+_PHYSICAL_10M = ("LAND", "LAKES")
 _POPULATED_PLACES_RES = "10m"
+# 10m shapefiles loaded directly via shapereader / NaturalEarthFeature
+# (no cfeature class). Listed as (category, name) pairs.
+_RAW_10M = (
+    ("cultural", "admin_2_counties_lakes"),  # basemap.add_counties
+    ("cultural", "roads"),                   # basemap.add_roads
+    ("physical", "lakes_north_america"),     # basemap.add_inland_lakes
+)
 
 
 def main() -> int:
@@ -40,12 +52,20 @@ def main() -> int:
         feature = getattr(cf, name).with_scale("50m")
         counts[name.lower()] = len(list(feature.geometries()))
 
+    for name in _PHYSICAL_10M:
+        feature = getattr(cf, name).with_scale("10m")
+        counts[f"{name.lower()}_10m"] = len(list(feature.geometries()))
+
     cities_path = shp.natural_earth(
         category="cultural",
         name="populated_places",
         resolution=_POPULATED_PLACES_RES,
     )
     counts["cities"] = len(list(shp.Reader(cities_path).records()))
+
+    for category, name in _RAW_10M:
+        path = shp.natural_earth(category=category, name=name, resolution="10m")
+        counts[name] = len(list(shp.Reader(path).records()))
 
     if not all(counts.values()):
         empty = [name for name, n in counts.items() if not n]

--- a/renderer/src/dras_renderer/app.py
+++ b/renderer/src/dras_renderer/app.py
@@ -17,6 +17,13 @@ from starlette.responses import Response
 from dras_renderer.cache import RenderCache
 from dras_renderer.config import Config
 from dras_renderer.metrics import REGISTRY, RENDER_DURATION, REQUESTS_TOTAL
+from dras_renderer.render import (
+    DEFAULT_HEIGHT,
+    DEFAULT_RANGE_KM,
+    DEFAULT_RANGE_MAX_KM,
+    DEFAULT_RANGE_MIN_KM,
+    DEFAULT_WIDTH,
+)
 from dras_renderer.s3 import S3Client
 from dras_renderer.service import (
     RenderRequest,
@@ -69,13 +76,17 @@ def build_app(config: Config | None = None) -> FastAPI:
         request: Request,
         station: str,
         product: str = Query("base_reflectivity"),
-        range_km: float = Query(230.0, ge=10.0, le=460.0),
+        range_km: float = Query(
+            DEFAULT_RANGE_KM,
+            ge=DEFAULT_RANGE_MIN_KM,
+            le=DEFAULT_RANGE_MAX_KM,
+        ),
         width: int = Query(
-            1000, ge=200, le=4000,
+            DEFAULT_WIDTH, ge=200, le=4000,
             description="Returned PNG width in pixels.",
         ),
         height: int = Query(
-            1000, ge=200, le=4000,
+            DEFAULT_HEIGHT, ge=200, le=4000,
             description=(
                 "Radar plot height in pixels. The returned PNG total "
                 "height equals this value plus an ~8% footer strip "

--- a/renderer/src/dras_renderer/basemap.py
+++ b/renderer/src/dras_renderer/basemap.py
@@ -16,7 +16,7 @@ import cartopy.crs as ccrs  # type: ignore[import-untyped]
 import cartopy.feature as cfeature  # type: ignore[import-untyped]
 import cartopy.io.shapereader as shapereader  # type: ignore[import-untyped]
 from adjustText import adjust_text  # type: ignore[import-untyped]
-from cartopy.feature import ShapelyFeature
+from cartopy.feature import NaturalEarthFeature, ShapelyFeature
 from matplotlib.patches import Rectangle
 from matplotlib.patheffects import withStroke
 from shapely.geometry import box as _shapely_box  # type: ignore[import-untyped]
@@ -93,6 +93,83 @@ def add_counties(ax: Any) -> None:
         linewidth=0.3,
     )
     ax.add_feature(feat, zorder=2)
+
+
+# Curated peak lists, keyed by ICAO station ID. Natural Earth has no
+# usable peak dataset at this scale and a global list would clutter the
+# render with summits irrelevant to the radar's coverage area, so peaks
+# are opt-in per station. Each entry is a (lat, lon, name) tuple in
+# WGS84. Adding a new station: append a key here. Stations without an
+# entry render no peak markers.
+_PEAKS_BY_STATION: dict[str, tuple[tuple[float, float, str], ...]] = {
+    # KATX (Camano Island) covers the Cascades stratovolcano line and
+    # the Olympics; these four are the prominent summits within ~150 km.
+    "KATX": (
+        (48.7768, -121.8145, "Mt Baker"),
+        (48.1118, -121.1149, "Glacier Peak"),
+        (46.8523, -121.7603, "Mt Rainier"),
+        (47.8013, -123.7108, "Mt Olympus"),
+    ),
+}
+
+
+def add_peaks(
+    ax: Any,
+    extent: tuple[float, float, float, float],
+    station_id: str,
+) -> None:
+    """Mark this station's curated summits with a triangle + label.
+
+    Triangles are the cartographic convention for mountain peaks. Labels
+    get the same white halo as cities so they survive over reflectivity.
+    Only peaks inside ``extent`` are drawn; stations without a peak list
+    render no markers (no warning — this is opt-in).
+    """
+    peaks = _PEAKS_BY_STATION.get(station_id.upper(), ())
+    if not peaks:
+        return
+    west, east, south, north = extent
+    for lat, lon, name in peaks:
+        if not (west <= lon <= east and south <= lat <= north):
+            continue
+        ax.plot(
+            lon, lat, marker="^",
+            markersize=7,
+            markerfacecolor="#5a3a26",  # earthy brown
+            markeredgecolor="black",
+            markeredgewidth=0.7,
+            transform=ccrs.PlateCarree(),
+            zorder=6,
+        )
+        t = ax.text(
+            lon + 0.04, lat + 0.02, name,
+            fontsize=7, color="black", fontweight="bold",
+            transform=ccrs.PlateCarree(), zorder=7,
+            clip_on=True,
+            path_effects=[withStroke(linewidth=2, foreground="white")],
+        )
+        t.set_clip_path(ax.patch)
+
+
+def add_inland_lakes(ax: Any) -> None:
+    """Draw Natural Earth's NA-specific inland lakes (10m).
+
+    The global ``lakes`` layer at 10m drops anything smaller than a Great
+    Lake — Lake Washington, Lake Sammamish, Lake Pontchartrain, Lake
+    Tahoe and friends are all absent. ``lakes_north_america`` (10m) fills
+    in metro-scale water bodies that radar viewers expect to see as
+    geographic anchors. Filled with WATER_COLOR and outlined in
+    LAKE_OUTLINE so they read as water on top of the LAND polygon.
+    """
+    feat = NaturalEarthFeature(
+        category="physical",
+        name="lakes_north_america",
+        scale="10m",
+        facecolor=WATER_COLOR,
+        edgecolor=LAKE_OUTLINE,
+        linewidth=0.4,
+    )
+    ax.add_feature(feat, zorder=3)
 
 
 # Road classes we keep (filters out local/residential/unclassified). The
@@ -230,6 +307,13 @@ def add_cities(
             clip_on=True,
             path_effects=[withStroke(linewidth=2, foreground="white")],
         )
+        # Force-clip to the axes patch — clip_on alone leaks for labels
+        # whose lat/lon position projects just past the projected xlim
+        # boundary (we lock that to a square, so it's slightly tighter
+        # than the lat/lon extent at non-center latitudes). Without this,
+        # an east-edge city's offset label (lon0 + 0.04°) draws past the
+        # axes box on the right.
+        t.set_clip_path(ax.patch)
         texts.append(t)
 
     if deconflict and texts:

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -50,8 +50,11 @@ def add_colorbar(ax: Any, opts: RenderOptions) -> None:
     ticks = list(range(lo, hi + 1, 20))
     cb.set_ticks(ticks)
     cb.ax.tick_params(labelsize=9, length=3, pad=2)
-    cb.outline.set_edgecolor("black")
-    cb.outline.set_linewidth(0.8)
+    # cb.outline is typed `Spine | None`; the matplotlib stubs flag
+    # method calls as "Spine not callable [operator]". At runtime it's
+    # always a Spine on a freshly constructed colorbar — silence mypy.
+    cb.outline.set_edgecolor("black")  # type: ignore[operator]
+    cb.outline.set_linewidth(0.8)  # type: ignore[operator]
     # Inline "dBZ" label to the right of the bar (instead of a centered
     # label below) so the bar + ticks + unit fit in a single horizontal
     # band without flowing past the radar axes bottom.

--- a/renderer/src/dras_renderer/furniture.py
+++ b/renderer/src/dras_renderer/furniture.py
@@ -26,22 +26,44 @@ def add_colorbar(ax: Any, opts: RenderOptions) -> None:
 
     Uses the same ``pyart_NWSRef`` cmap and (vmin, vmax) the radar plot
     is rendered with so the inset is exactly the active scale.
+
+    Sized for legibility: thicker bar, integer ticks every 10 dBZ, a
+    thin black border, and an explicit "dBZ" unit label.
     """
     cax = inset_axes(
         ax,
-        width="28%", height="3%",
+        width="34%", height="4.5%",
         loc="lower left",
-        bbox_to_anchor=(0.02, 0.02, 1, 1),
+        bbox_to_anchor=(0.02, 0.025, 1, 1),
         bbox_transform=ax.transAxes,
         borderpad=0,
     )
-    cax.set_facecolor((1, 1, 1, 0.85))
+    cax.set_facecolor((1, 1, 1, 0.9))
     sm = ScalarMappable(norm=Normalize(vmin=opts.vmin, vmax=opts.vmax),
                         cmap="pyart_NWSRef")
     cb = plt.colorbar(sm, cax=cax, orientation="horizontal")
-    cb.set_ticks([-20, 0, 20, 40, 60, 75])
-    cb.ax.tick_params(labelsize=6, length=2, pad=1)
-    cb.set_label("dBZ", fontsize=6, labelpad=1)
+    # Ticks every 20 dBZ — 11 ticks at 10-dBZ spacing crowd into the
+    # 340 px bar and the appended upper bound (e.g. 75) glues onto the
+    # last decade tick (70). Even spacing reads cleanly at this size.
+    lo = int(math.ceil(opts.vmin / 20.0) * 20)
+    hi = int(math.floor(opts.vmax / 20.0) * 20)
+    ticks = list(range(lo, hi + 1, 20))
+    cb.set_ticks(ticks)
+    cb.ax.tick_params(labelsize=9, length=3, pad=2)
+    cb.outline.set_edgecolor("black")
+    cb.outline.set_linewidth(0.8)
+    # Inline "dBZ" label to the right of the bar (instead of a centered
+    # label below) so the bar + ticks + unit fit in a single horizontal
+    # band without flowing past the radar axes bottom.
+    bar_box = cax.get_position()
+    ax.text(
+        bar_box.x1 + 0.005, (bar_box.y0 + bar_box.y1) / 2,
+        "dBZ",
+        transform=ax.figure.transFigure,
+        ha="left", va="center",
+        fontsize=9, fontweight="bold", color="black",
+        zorder=11,
+    )
 
 
 def add_scale_bar(ax: Any, length_km: float = 20.0) -> None:
@@ -77,21 +99,67 @@ def add_scale_bar(ax: Any, length_km: float = 20.0) -> None:
     )
 
 
+def add_radar_marker(
+    ax: Any, lat: float, lon: float, station_id: str
+) -> None:
+    """Mark the radar site with a scope-style glyph + station label.
+
+    Drawn as a small dot inside an open ring — a "scope center" cue that
+    reads as radar at a glance and gives the eye a fixed origin for the
+    sweep. The station ID sits to the right with a white halo so it
+    survives over reflectivity returns.
+    """
+    import matplotlib.patheffects as path_effects
+
+    pc = ccrs.PlateCarree()
+    # Outer ring: open circle, 10pt diameter — the "scope" silhouette.
+    ax.plot(
+        lon, lat, marker="o", markersize=10,
+        markerfacecolor="none", markeredgecolor="black", markeredgewidth=1.2,
+        transform=pc, zorder=11,
+    )
+    # Inner dot: solid 3pt — the antenna location.
+    ax.plot(
+        lon, lat, marker="o", markersize=3,
+        markerfacecolor="black", markeredgecolor="black",
+        transform=pc, zorder=12,
+    )
+    label = ax.text(
+        lon, lat, f"  {station_id}",
+        transform=pc,
+        fontsize=8, fontweight="bold", color="black",
+        ha="left", va="center", zorder=12,
+    )
+    label.set_path_effects([
+        path_effects.Stroke(linewidth=2.5, foreground="white"),
+        path_effects.Normal(),
+    ])
+
+
 def add_north_arrow(ax: Any) -> None:
     """Place a small N + upward arrow glyph in the upper-right of the axes.
 
     Uses axes-fraction coords so position is invariant to data extent.
+    The arrow is drawn separately from the "N" label so the head points
+    *up* (toward the label) — ``annotate`` always points its arrow toward
+    ``xy``, so the previous single-call form had the head at the bottom.
     """
+    # Upward-pointing arrow: tail at 0.91, head at 0.96.
     ax.annotate(
-        "N",
-        xy=(0.95, 0.93),
-        xytext=(0.95, 0.97),
+        "",
+        xy=(0.95, 0.96),
+        xytext=(0.95, 0.91),
         xycoords="axes fraction",
         textcoords="axes fraction",
-        ha="center", va="bottom",
-        fontsize=10, fontweight="bold", color="black",
         arrowprops=dict(facecolor="black", edgecolor="black",
                         width=2, headwidth=8, headlength=8),
+        zorder=10,
+    )
+    ax.text(
+        0.95, 0.97, "N",
+        transform=ax.transAxes,
+        ha="center", va="bottom",
+        fontsize=12, fontweight="bold", color="black",
         zorder=10,
     )
 
@@ -121,6 +189,6 @@ def add_footer(
     )
     footer_ax.text(
         0.5, 0.5, text,
-        ha="center", va="center", fontsize=8, color="#333",
+        ha="center", va="center", fontsize=12, color="#333",
         transform=footer_ax.transAxes,
     )

--- a/renderer/src/dras_renderer/render.py
+++ b/renderer/src/dras_renderer/render.py
@@ -26,18 +26,48 @@ from dras_renderer.decode import DecodedScan
 from dras_renderer.version import VERSION
 
 
+DEFAULT_RANGE_KM: float = 150.0
+"""Canonical default radar view range, in km half-extent.
+
+Single source of truth — referenced by ``RenderOptions.range_km``,
+``service.RenderRequest.range_km``, and the HTTP Query default in
+``app.py``. Change this constant and all three layers move together.
+
+150 km is wide enough to keep regional context (Olympic Peninsula,
+Cascades, BC border for KATX) while still leaving named cities
+legible; tighter values (50–75 km) lose the synoptic feel, and the
+radar's nominal 230 km range pushes named places to pinpricks.
+"""
+
+DEFAULT_RANGE_MIN_KM: float = 10.0
+DEFAULT_RANGE_MAX_KM: float = 460.0
+
+DEFAULT_WIDTH: int = 1000
+DEFAULT_HEIGHT: int = 1100
+"""Canonical default radar plot dimensions, in pixels.
+
+Single source of truth — referenced by ``RenderOptions``,
+``service.RenderRequest``, and the HTTP Query defaults in ``app.py``.
+
+Width is fixed by ``range_km`` (x-half-extent); height is taller than
+width by design so the projected view extends further N-S, keeping
+edge-of-coverage features (e.g. Mt Rainier ~150 km south of KATX) off
+the south margin instead of glued to it.
+"""
+
+
 @dataclass(frozen=True)
 class RenderOptions:
     """Options controlling render output."""
 
-    width: int = 1000
-    height: int = 1000
-    # 150 km centers the view on the Puget Sound corridor (radar at Camano
-    # Island for KATX) while keeping the inland Cascades and Olympia in
-    # frame. The radar's nominal 230 km range zooms out so far that named
-    # cities are pinpricks and sub-county detail is illegible.
-    range_km: float = 150.0
+    width: int = DEFAULT_WIDTH
+    height: int = DEFAULT_HEIGHT
+    range_km: float = DEFAULT_RANGE_KM
     dpi: int = 100
+
+    # White margin (in pixels) between the radar axes and the figure edge.
+    # Frames the basemap so it doesn't bleed to the PNG border.
+    border_px: int = 15
 
     # Reflectivity color scale bounds, dBZ.
     vmin: float = -20.0
@@ -82,12 +112,16 @@ class RenderOptions:
     # New basemap layers (Task 4–7).
     show_counties: bool = True
     show_roads: bool = True
+    show_peaks: bool = True
 
     # Cartographic furniture (Task 9–12).
     show_colorbar: bool = True
     show_scale_bar: bool = True
     show_north_arrow: bool = True
     show_footer: bool = True
+    # Mark the radar antenna location with a scope-style glyph + station
+    # label. Useful as a fixed reference point for the sweep origin.
+    show_radar_marker: bool = True
 
     # Label deconfliction (Task 8). When False, falls back to the existing
     # fixed-offset placement with a white text halo.
@@ -158,9 +192,18 @@ def _render_figure(
     # ax is a Cartopy GeoAxes (since projection= is passed) — typed as Any
     # because mpl stubs return plain Axes from add_axes, which lacks the
     # GeoAxes-specific set_extent/add_feature methods we need below.
+    # ``border_px`` insets the radar axes on all four sides so the basemap
+    # is framed by white margin instead of bleeding to the figure edge.
     radar_top_frac = opts.height / total_height_px
+    inset_x = opts.border_px / opts.width
+    inset_y = opts.border_px / total_height_px
     ax: Any = fig.add_axes(
-        (0, 1 - radar_top_frac, 1, radar_top_frac),
+        (
+            inset_x,
+            (1 - radar_top_frac) + inset_y,
+            1 - 2 * inset_x,
+            radar_top_frac - 2 * inset_y,
+        ),
         projection=projection,
     )
     footer_ax = (
@@ -170,8 +213,20 @@ def _render_figure(
     # 1° lat ≈ 111 km everywhere; 1° lon ≈ 111 cos(lat) km. Without the
     # cos(lat) correction the east-west extent stretches by 33% at KATX
     # (lat ~48°) and ~50% at high-latitude AK stations.
-    delta_lat = opts.range_km / 111.0
-    delta_lon = delta_lat / max(math.cos(math.radians(center_lat)), 1e-6)
+    #
+    # ``range_km`` defines the E-W half-extent. The N-S half-extent
+    # scales with the radar axes' pixel aspect — when the figure is
+    # taller than wide, the visible view extends further north/south so
+    # edge-of-coverage features (e.g. Mt Rainier south of KATX) don't
+    # crowd against the bottom margin.
+    ax_w_px = (1 - 2 * inset_x) * opts.width
+    ax_h_px = (radar_top_frac - 2 * inset_y) * total_height_px
+    y_aspect = ax_h_px / ax_w_px
+
+    delta_lon = opts.range_km / (
+        111.0 * max(math.cos(math.radians(center_lat)), 1e-6)
+    )
+    delta_lat = (opts.range_km / 111.0) * y_aspect
     extent = (
         center_lon - delta_lon,
         center_lon + delta_lon,
@@ -179,6 +234,23 @@ def _render_figure(
         center_lat + delta_lat,
     )
     ax.set_extent(extent, crs=ccrs.PlateCarree())
+    # Lock the visible projected box to a rectangle sized to the axes
+    # aspect ratio, in meters. The projection is centered on
+    # (center_lat, center_lon), so (0, 0) in projected coords is the
+    # view center; a symmetric ±range_m_x by ±range_m_y box fills the
+    # axes box exactly.
+    #
+    # Without this, Cartopy's set_extent projects the lat/lon corners
+    # into a slightly-curved quadrilateral whose bounding rectangle has
+    # a ~2.5% non-unit aspect at ~48° lat — and Cartopy's default
+    # ``adjustable="box"`` then shrinks the axes box to match, leaving
+    # uneven white margins inside the figure. Locking the projected
+    # limits sidesteps the auto-aspect entirely so all four margins
+    # equal the figure-level border_px inset.
+    range_m_x = opts.range_km * 1000.0
+    range_m_y = range_m_x * y_aspect
+    ax.set_xlim(-range_m_x, range_m_x)
+    ax.set_ylim(-range_m_y, range_m_y)
 
     basemap.add_land_water_fill(ax, extent)
 
@@ -194,12 +266,22 @@ def _render_figure(
         basemap.add_roads(ax, extent)
     ax.add_feature(cfeature.COASTLINE.with_scale("50m"), edgecolor="black", linewidth=0.5)
     if opts.show_lakes:
+        # Two layers — the global ``lakes`` shapefile carries the Great
+        # Lakes / large international lakes, and the NA-specific
+        # ``lakes_north_america`` carries metro-scale lakes (Lake
+        # Washington, Lake Tahoe, Lake Pontchartrain) that the global
+        # layer drops at every resolution. Both fill with WATER_COLOR
+        # since the 10m LAND polygon covers the bottom water rectangle
+        # wherever it touches a lake bed — a hollow outline alone leaves
+        # cream-on-cream and the lake disappears.
         ax.add_feature(
-            cfeature.LAKES.with_scale("50m"),
-            facecolor="none",
-            edgecolor="#4a6da7",
+            cfeature.LAKES.with_scale("10m"),
+            facecolor=basemap.WATER_COLOR,
+            edgecolor=basemap.LAKE_OUTLINE,
             linewidth=0.4,
+            zorder=3,
         )
+        basemap.add_inland_lakes(ax)
     if opts.show_borders:
         ax.add_feature(
             cfeature.BORDERS.with_scale("50m"),
@@ -242,6 +324,12 @@ def _render_figure(
             opts.cities_max_scalerank,
             deconflict=opts.deconflict_labels,
         )
+
+    if opts.show_peaks:
+        basemap.add_peaks(ax, extent, scan.station_id)
+
+    if opts.show_radar_marker:
+        furniture.add_radar_marker(ax, radar_lat, radar_lon, scan.station_id)
 
     if opts.show_colorbar:
         furniture.add_colorbar(ax, opts)

--- a/renderer/src/dras_renderer/service.py
+++ b/renderer/src/dras_renderer/service.py
@@ -11,7 +11,13 @@ from cachetools import LRUCache
 from dras_renderer.cache import RenderCache
 from dras_renderer.decode import DecodedScan, decode_level2_archive
 from dras_renderer.metrics import S3_ERRORS_TOTAL
-from dras_renderer.render import RenderOptions, render_base_reflectivity
+from dras_renderer.render import (
+    DEFAULT_HEIGHT,
+    DEFAULT_RANGE_KM,
+    DEFAULT_WIDTH,
+    RenderOptions,
+    render_base_reflectivity,
+)
 from dras_renderer.s3 import S3Client, S3Error
 from dras_renderer.version import VERSION
 
@@ -20,9 +26,9 @@ from dras_renderer.version import VERSION
 class RenderRequest:
     station: str
     product: str = "base_reflectivity"
-    range_km: float = 230.0
-    width: int = 800
-    height: int = 800
+    range_km: float = DEFAULT_RANGE_KM
+    width: int = DEFAULT_WIDTH
+    height: int = DEFAULT_HEIGHT
     # Optional view-center override. None means "center on the radar".
     center_lat: float | None = None
     center_lon: float | None = None

--- a/renderer/tests/test_render.py
+++ b/renderer/tests/test_render.py
@@ -143,10 +143,15 @@ def test_render_options_has_new_layer_toggles() -> None:
 
 def test_render_options_defaults_match_route_defaults() -> None:
     """RenderOptions().width/.height must match the FastAPI route's
-    Query(...) defaults (1000×1000) so direct library use produces the
-    same dimensions as the HTTP API. Prior drift here gave library
-    callers an 800x864 PNG while the route produced 1000x1080.
+    Query(...) defaults so direct library use produces the same
+    dimensions as the HTTP API. Prior drift here gave library callers
+    an 800x864 PNG while the route produced 1000x1080.
+
+    All three layers (RenderOptions, RenderRequest, FastAPI Query)
+    pull from the DEFAULT_WIDTH / DEFAULT_HEIGHT constants in render.py
+    so this test asserts the constants are the active source of truth.
     """
+    from dras_renderer.render import DEFAULT_HEIGHT, DEFAULT_WIDTH
     opts = RenderOptions()
-    assert opts.width == 1000
-    assert opts.height == 1000
+    assert opts.width == DEFAULT_WIDTH
+    assert opts.height == DEFAULT_HEIGHT


### PR DESCRIPTION
## Summary

Iterative session focused on visual quality and geographic anchoring of the rendered radar PNG. The default render is now noticeably more professional and spatially intuitive. Bundles a container-runtime bug fix that was masking missing Cartopy cache layers.

### Visual upgrades
- **Scope-style radar marker** (open ring + center dot) at the antenna location with haloed station label.
- **Per-station peak markers** — KATX gets Mt Baker, Glacier Peak, Mt Rainier, Mt Olympus drawn as brown triangles via a new `_PEAKS_BY_STATION` registry in `basemap.py`. Stations without an entry render no markers (opt-in, no warning).
- **Inland lakes layer** (`ne_10m_lakes_north_america`) wired in so Lake Washington, Lake Tahoe, Lake Pontchartrain, etc. render as water. The global `ne_10m_lakes` shapefile drops every lake smaller than a Great Lake at every resolution.
- **North arrow** flipped to point up (was inverted in v2.12.0).
- **Colorbar** beefed up: thicker bar, integer ticks every 20 dBZ, inline "dBZ" label to the right of the bar, thin black outline, positioned just above the bottom border.
- **Footer text** bumped 8 pt → 12 pt.
- **15 px white margin** frames the radar plot cleanly instead of bleeding to the figure edges.
- **City labels** force-clipped to the axes patch so east-edge labels don't leak past the right boundary.

### Default render shape
- Default plot height bumped 1000 → 1100 so southern coverage features (e.g. Mt Rainier at the edge of KATX's view) get breathing room above the bottom border.
- Y-axis projected limit now scales with the axes pixel aspect ratio so a taller figure actually shows more N-S area instead of just adding whitespace.
- Projected `xlim`/`ylim` locked explicitly so Cartopy's default `adjustable="box"` doesn't introduce uneven internal padding (previously sides=14 px while top/bottom=26 px).

### Refactor: single source of truth for defaults
- `DEFAULT_RANGE_KM`, `DEFAULT_WIDTH`, `DEFAULT_HEIGHT` consolidated as module-level constants in `render.py` and consumed by `service.RenderRequest` and the FastAPI `Query` defaults. The three layers can no longer drift.
- Prior drift had the API silently using `range_km=230` while the dataclass advertised 150 — found and fixed mid-session.
- Existing test `test_render_options_defaults_match_route_defaults` updated to assert against the constants directly.

### Container fix bundled
The prewarmed Cartopy cache in `scripts/cartopy_cache.py` was missing `admin_2_counties_lakes`, `roads`, `LAND` (10m), and (now) `lakes_north_america`. Without them the unprivileged container uid hit `PermissionError` trying to download missing layers at request time. The script's docstring already required this list be kept in sync with `render.py` — it had drifted. Build now reports all layers warmed.

## Test plan

- [x] `uv run pytest tests/` — 67 passed
- [x] Container build succeeds: `docker build -t dras-renderer:local .`
- [x] Container renders KATX without `PermissionError` (was 500ing before the cartopy_cache fix)
- [x] Visual review of `/render/KATX` output — peaks visible, Lake Washington rendering as water, equal margins, colorbar legible
- [ ] Deploy to Talos `selfhosted` ns and confirm in-cluster render matches local

🤖 Generated with [Claude Code](https://claude.com/claude-code)