### PR TITLE
fix(monitor): fetch radar image only on change, not every poll

### DIFF
--- a/dras/internal/monitor/monitor.go
+++ b/dras/internal/monitor/monitor.go
@@ -92,6 +92,13 @@ func (m *Monitor) fetchAndReportRadarData(ctx context.Context, stationIDs []stri
 }
 
 // processStation handles the processing of a single radar station.
+//
+// The image source is invoked lazily — only when a notification will
+// carry the freshly-rendered image (first run, or a VCP change). The
+// previous "fetch every poll, attach on change" pattern made the
+// renderer absorb a request per station per CheckInterval (~12/hr per
+// station with the 5 min default) just to discard most of them. Only
+// poll the renderer when the result will reach a user.
 func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 	stationLogger := slog.Default().With("station", stationID)
 	stationLogger.Debug("Fetching radar data")
@@ -99,11 +106,6 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 	if err != nil {
 		return fmt.Errorf("error fetching radar data for station %s: %w", stationID, err)
 	}
-
-	// Poll and store the latest radar image so it can be attached to the
-	// next change notification. Image fetch failures are logged but do not
-	// fail the whole poll.
-	radarImage := m.fetchRadarImage(ctx, stationID, stationLogger)
 
 	// Check if we need to initialize or if this is first run
 	m.mu.Lock()
@@ -124,6 +126,10 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 		if m.config.DryRun {
 			stationLogger.Debug(fmt.Sprintf("Would send startup notification: %s", initialMessage))
 		} else {
+			// First run always carries the freshly-rendered image so
+			// the user has visual context the moment the monitor
+			// comes online.
+			radarImage := m.fetchRadarImage(ctx, stationID, stationLogger)
 			attachment := m.attachmentForStation(stationID, radarImage)
 			if err := m.notifyService.SendNotificationWithAttachment(ctx, "DRAS Startup", initialMessage, attachment); err != nil {
 				return fmt.Errorf("failed to send startup notification for station %s: %w", stationID, err)
@@ -143,31 +149,40 @@ func (m *Monitor) processStation(ctx context.Context, stationID string) error {
 	alertConfig := m.config.AlertConfig
 
 	changed, changeMessage := radar.CompareData(lastData, newRadarData, alertConfig)
-	if changed {
-		slog.Info("Radar data changed",
-			"station", stationID,
-			"station_name", newRadarData.Name,
-			"change", changeMessage,
-		)
-
-		vcpChanged := lastData.VCP != newRadarData.VCP
-
-		if m.config.DryRun {
-			stationLogger.Debug(fmt.Sprintf("Would send change notification: %s", changeMessage))
-		} else {
-			title := fmt.Sprintf("%s Update", stationID)
-			attachment := m.attachmentForChange(stationID, vcpChanged, radarImage, stationLogger)
-			if err := m.notifyService.SendNotificationWithAttachment(ctx, title, changeMessage, attachment); err != nil {
-				return fmt.Errorf("failed to send change notification for station %s: %w", stationID, err)
-			}
-			stationLogger.Info("Change notification sent successfully")
-		}
-		m.mu.Lock()
-		m.radarDataMap[stationID]["last"] = newRadarData
-		m.mu.Unlock()
-	} else {
+	if !changed {
 		stationLogger.Debug("No changes detected in radar data")
+		return nil
 	}
+
+	slog.Info("Radar data changed",
+		"station", stationID,
+		"station_name", newRadarData.Name,
+		"change", changeMessage,
+	)
+
+	vcpChanged := lastData.VCP != newRadarData.VCP
+
+	if m.config.DryRun {
+		stationLogger.Debug(fmt.Sprintf("Would send change notification: %s", changeMessage))
+	} else {
+		// Only invoke the image source when the notification will
+		// actually carry an attachment (currently: VCP changes only).
+		// Other changes — power source, mode without VCP shift, etc.
+		// — reach the user as text-only and don't justify a render.
+		var radarImage *image.Image
+		if vcpChanged {
+			radarImage = m.fetchRadarImage(ctx, stationID, stationLogger)
+		}
+		title := fmt.Sprintf("%s Update", stationID)
+		attachment := m.attachmentForChange(stationID, vcpChanged, radarImage, stationLogger)
+		if err := m.notifyService.SendNotificationWithAttachment(ctx, title, changeMessage, attachment); err != nil {
+			return fmt.Errorf("failed to send change notification for station %s: %w", stationID, err)
+		}
+		stationLogger.Info("Change notification sent successfully")
+	}
+	m.mu.Lock()
+	m.radarDataMap[stationID]["last"] = newRadarData
+	m.mu.Unlock()
 
 	return nil
 }

--- a/dras/internal/monitor/monitor_test.go
+++ b/dras/internal/monitor/monitor_test.go
@@ -272,6 +272,130 @@ func TestNonVCPChangeOmitsAttachment(t *testing.T) {
 	}
 }
 
+// TestNoChangePollSkipsImageSource pins the lazy-fetch behavior: a poll
+// where nothing in the radar data changed must not invoke the image
+// source. The previous always-poll-the-renderer pattern absorbed one
+// renderer request per station per CheckInterval — at the 5-min default
+// that's 12 wasted renders per hour per station.
+func TestNoChangePollSkipsImageSource(t *testing.T) {
+	var imageRequests int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&imageRequests, 1)
+		w.Header().Set("Content-Type", "image/gif")
+		w.Write([]byte("img"))
+	}))
+	defer server.Close()
+
+	imgSvc := image.New(image.Config{URLTemplate: server.URL + "/{station}.gif"})
+
+	radarMock := radar.NewMockDataFetcher()
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R31", Mode: "Clear Air",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Utility", GenState: "Off",
+	})
+
+	notifyMock := notify.NewMockNotifier()
+	cfg := &config.Config{
+		DryRun:        false,
+		CheckInterval: time.Minute,
+		AlertConfig:   radar.AlertConfig{VCP: true},
+	}
+
+	m := New(radarMock, notifyMock, imgSvc, cfg)
+	ctx := context.Background()
+
+	// First poll seeds the cache and triggers the startup notification —
+	// startup always fetches one image.
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("first processStation() error: %v", err)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 1 {
+		t.Fatalf("after first poll: imageRequests = %d, want 1 (startup)", got)
+	}
+
+	// Second poll: identical radar data. No change detected, no
+	// notification fired, and crucially — no renderer call.
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("second processStation() error: %v", err)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 1 {
+		t.Errorf("after no-change poll: imageRequests = %d, want 1 (no extra fetch)", got)
+	}
+	if got := len(notifyMock.GetNotifications()); got != 1 {
+		t.Errorf("after no-change poll: notifications = %d, want 1 (only startup)", got)
+	}
+
+	// Third poll: same again. Still nothing.
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("third processStation() error: %v", err)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 1 {
+		t.Errorf("after second no-change poll: imageRequests = %d, want 1", got)
+	}
+}
+
+// TestNonVCPChangePollSkipsImageSource pins the same lazy-fetch behavior
+// for the more subtle case of a non-VCP change: power-source flips don't
+// carry an attachment, so they must not invoke the renderer either.
+func TestNonVCPChangePollSkipsImageSource(t *testing.T) {
+	var imageRequests int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&imageRequests, 1)
+		w.Header().Set("Content-Type", "image/gif")
+		w.Write([]byte("img"))
+	}))
+	defer server.Close()
+
+	imgSvc := image.New(image.Config{URLTemplate: server.URL + "/{station}.gif"})
+
+	radarMock := radar.NewMockDataFetcher()
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R31", Mode: "Clear Air",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Utility", GenState: "Off",
+	})
+
+	notifyMock := notify.NewMockNotifier()
+	cfg := &config.Config{
+		DryRun:        false,
+		CheckInterval: time.Minute,
+		AlertConfig:   radar.AlertConfig{VCP: true, PowerSource: true},
+	}
+
+	m := New(radarMock, notifyMock, imgSvc, cfg)
+	ctx := context.Background()
+
+	// Startup poll — 1 fetch.
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("first processStation() error: %v", err)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 1 {
+		t.Fatalf("after first poll: imageRequests = %d, want 1", got)
+	}
+
+	// Change power source only — VCP unchanged, no attachment expected,
+	// no renderer call expected.
+	radarMock.SetResponse("KATX", &radar.Data{
+		Name: "Seattle", VCP: "R31", Mode: "Clear Air",
+		Status: "Online", OperabilityStatus: "Normal",
+		PowerSource: "Generator", GenState: "On",
+	})
+	if err := m.processStation(ctx, "KATX"); err != nil {
+		t.Fatalf("second processStation() error: %v", err)
+	}
+	if got := atomic.LoadInt64(&imageRequests); got != 1 {
+		t.Errorf("after non-VCP change: imageRequests = %d, want 1 (no extra fetch)", got)
+	}
+	notifs := notifyMock.GetNotifications()
+	if len(notifs) != 2 {
+		t.Fatalf("expected 2 notifications, got %d", len(notifs))
+	}
+	if notifs[1].Attachment != nil {
+		t.Errorf("non-VCP change should not have attachment, got %+v", notifs[1].Attachment)
+	}
+}
+
 // TestRendererModeDeliversAttachment exercises the full happy path with the
 // renderer.Client image source. A renderer stub returns a unique PNG per
 // request so we can assert which body was attached.


### PR DESCRIPTION
## Summary

`processStation` was calling the image source on every `CheckInterval` tick, regardless of whether the radar data had changed. The fetched image was then discarded for all polls except the ones that triggered a notification (first run, or VCP change). At the 5 min default that absorbed ~12 wasted renderer calls per station per hour.

Move `fetchRadarImage` into the two paths that actually need an image:
- **First run** — startup notification always carries an image so the user has visual context the moment the monitor comes online.
- **VCP change** — the only mid-run change type that ships an attachment (per `attachmentForChange`).

Other change types (power source flips, mode shifts without VCP) reach the user as text-only and don't justify a render. No-change polls now skip the image source entirely.

## Why

The renderer is the heaviest hop in the pipeline (S3 fetch + Py-ART decode + Cartopy plot per request). Burning a full render every 5 min per station to discard the result was pure waste — and at scale it scales linearly with both station count and poll frequency.

## Tests

Two new tests pin the regression:
- `TestNoChangePollSkipsImageSource` — repeated identical-data polls fetch exactly once (the startup poll), never on subsequent ticks.
- `TestNonVCPChangePollSkipsImageSource` — power-source flips don't trigger a fetch even though they fire a notification.

`TestVCPChangeDeliversAttachment` continues to pass: the freshly-rendered image still lands on the change notification because `fetchRadarImage` runs just-in-time in the VCP-change branch instead of opportunistically before comparison.

## Test plan

- [x] `go test ./internal/monitor/...` — passes (full suite)
- [x] `go test ./...` — all packages green
- [x] Verified the new tests assert request counts at each poll boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)