### PR TITLE
refactor(radar): typed status fields + soft-fail GenState parser (fixes #129)

### DIFF
--- a/dras/internal/radar/benchmark_test.go
+++ b/dras/internal/radar/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 
 // BenchmarkGetMode tests performance of VCP to mode conversion
 func BenchmarkGetMode(b *testing.B) {
-	vcps := []string{"R31", "R35", "R12", "R112", "R212", "R215"}
+	vcps := []VCP{VCPR31, VCPR35, VCPR12, VCPR112, VCPR212, VCPR215}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/dras/internal/radar/compare.go
+++ b/dras/internal/radar/compare.go
@@ -1,6 +1,7 @@
 package radar
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -14,41 +15,55 @@ type AlertConfig struct {
 	GenState    bool
 }
 
-// CompareData compares the old and new radar data and returns whether there are any changes and the details of the changes.
-// It takes two pointers to Data structs as input and returns a boolean indicating if there are any changes and a string containing the details of the changes.
+// CompareData compares old and new radar data and returns whether any
+// alert-enabled field changed, plus a multi-line message describing the
+// changes.
+//
+// Per-field rule: a change is reported only when (a) the alert is enabled,
+// (b) the new value is not the field's Unknown sentinel, and (c) old and new
+// differ. Condition (b) is the noise-floor — when NWS returns a degraded
+// payload that parses to <Type>Unknown for some field, the monitor would
+// otherwise fire spurious change notifications on the OK→Unknown flip and
+// again on the Unknown→OK recovery. The caller (monitor.processStation) only
+// updates the cache when `changed` is true, so skipping the flip leaves the
+// cache holding the last known-good value; recovery to the same value
+// produces a true no-change.
+//
+// The skip is one-sided (new == Unknown only). If a previous cached value
+// was somehow Unknown (e.g. first-run with degraded data), a subsequent
+// known value is a genuine state-clarification and should fire.
 func CompareData(oldData, newData *Data, alertConfig AlertConfig) (bool, string) {
 	var changes []string
 
-	if alertConfig.VCP && oldData.VCP != newData.VCP {
-		// Look up the new VCP in the catalog. Known VCPs surface their
-		// AlertText (preferred) or fall back to "<Mode> Mode Active".
-		// Unknown VCPs report the raw transition so users still see what
-		// changed.
-		if info, err := GetVCPInfo(newData.VCP); err == nil {
-			switch {
-			case info.AlertText != "":
-				changes = append(changes, info.AlertText)
-			default:
-				changes = append(changes, fmt.Sprintf("%s Mode Active", info.Mode))
-			}
-		} else {
+	if alertConfig.VCP && newData.VCP != VCPUnknown && oldData.VCP != newData.VCP {
+		// Known VCPs surface their AlertText (preferred) or fall back to
+		// "<Mode> Mode Active". An unknown VCP reaching this branch means
+		// oldData.VCP was Unknown (we only skip when newData is Unknown) —
+		// report the raw transition so users still see what changed.
+		info, err := GetVCPInfo(newData.VCP)
+		switch {
+		case err == nil && info.AlertText != "":
+			changes = append(changes, info.AlertText)
+		case err == nil:
+			changes = append(changes, fmt.Sprintf("%s Mode Active", info.Mode))
+		case errors.Is(err, ErrUnknownVCP):
 			changes = append(changes, fmt.Sprintf("Radar mode changed from %s to %s", oldData.VCP, newData.VCP))
 		}
 	}
 
-	if alertConfig.Status && oldData.Status != newData.Status {
+	if alertConfig.Status && newData.Status != StatusUnknown && oldData.Status != newData.Status {
 		changes = append(changes, fmt.Sprintf("Radar status changed from %s to %s", oldData.Status, newData.Status))
 	}
 
-	if alertConfig.Operability && oldData.OperabilityStatus != newData.OperabilityStatus {
+	if alertConfig.Operability && newData.OperabilityStatus != OpStatusUnknown && oldData.OperabilityStatus != newData.OperabilityStatus {
 		changes = append(changes, fmt.Sprintf("Radar operability changed from %s to %s", oldData.OperabilityStatus, newData.OperabilityStatus))
 	}
 
-	if alertConfig.PowerSource && oldData.PowerSource != newData.PowerSource {
+	if alertConfig.PowerSource && newData.PowerSource != PowerSourceUnknown && oldData.PowerSource != newData.PowerSource {
 		changes = append(changes, fmt.Sprintf("Power source changed from %s to %s", oldData.PowerSource, newData.PowerSource))
 	}
 
-	if alertConfig.GenState && oldData.GenState != newData.GenState {
+	if alertConfig.GenState && newData.GenState != GenStateUnknown && oldData.GenState != newData.GenState {
 		changes = append(changes, fmt.Sprintf("Generator state changed from %s to %s", oldData.GenState, newData.GenState))
 	}
 
@@ -58,4 +73,3 @@ func CompareData(oldData, newData *Data, alertConfig AlertConfig) (bool, string)
 
 	return false, ""
 }
-

--- a/dras/internal/radar/compare_test.go
+++ b/dras/internal/radar/compare_test.go
@@ -160,6 +160,114 @@ func TestCompareData(t *testing.T) {
 		}
 	})
 
+	// Skip-Unknown behavior (issue #129). A degraded NWS payload produces
+	// <Type>Unknown values for the affected fields; the comparator must not
+	// fire a change notification for a flip TO an Unknown sentinel, even
+	// though the strings differ. Cache update is gated on `changed` in the
+	// caller, so this leaves the cache holding the last known-good value
+	// and a subsequent recovery to that same value produces a clean
+	// no-change.
+	t.Run("skips flip to Unknown on every field", func(t *testing.T) {
+		degraded := &Data{
+			Name:              "KATX",
+			VCP:               VCPUnknown,
+			Mode:              ModeUnknown,
+			Status:            StatusUnknown,
+			OperabilityStatus: OpStatusUnknown,
+			PowerSource:       PowerSourceUnknown,
+			GenState:          GenStateUnknown,
+		}
+
+		alertConfig := AlertConfig{
+			VCP:         true,
+			Status:      true,
+			Operability: true,
+			PowerSource: true,
+			GenState:    true,
+		}
+
+		changed, message := CompareData(oldData, degraded, alertConfig)
+		if changed {
+			t.Errorf("Expected no changes for OK→Unknown flip on every field, got changed=true, message=%q", message)
+		}
+		if message != "" {
+			t.Errorf("Expected empty message for OK→Unknown flip, got %q", message)
+		}
+	})
+
+	t.Run("flip FROM Unknown is reported (recovery)", func(t *testing.T) {
+		// First-run / post-recovery: previous cached value was Unknown
+		// (e.g. cache seeded during a degraded poll). A subsequent known
+		// value IS a genuine state-clarification and should fire.
+		degraded := &Data{
+			Name:              "KATX",
+			VCP:               VCPUnknown,
+			Mode:              ModeUnknown,
+			Status:            StatusUnknown,
+			OperabilityStatus: OpStatusUnknown,
+			PowerSource:       PowerSourceUnknown,
+			GenState:          GenStateUnknown,
+		}
+
+		recovered := &Data{
+			Name:              "KATX",
+			VCP:               VCPR12,
+			Mode:              ModePrecipitation,
+			Status:            "Operate",
+			OperabilityStatus: "RDA - On-line",
+			PowerSource:       PowerSourceUtility,
+			GenState:          GenStateOff,
+		}
+
+		alertConfig := AlertConfig{
+			VCP:         true,
+			Status:      true,
+			Operability: true,
+			PowerSource: true,
+			GenState:    true,
+		}
+
+		changed, message := CompareData(degraded, recovered, alertConfig)
+		if !changed {
+			t.Error("Expected change to be reported for Unknown→OK recovery")
+		}
+		// VCP path: oldData=Unknown, newData=R12 known → "Precipitation Mode Active".
+		if !strings.Contains(message, "Precipitation Mode Active") {
+			t.Errorf("Expected precipitation message on recovery, got %q", message)
+		}
+		// Status: Unknown → Operate is reported as a normal flip.
+		if !strings.Contains(message, "status changed from Unknown to Operate") {
+			t.Errorf("Expected status change message on recovery, got %q", message)
+		}
+	})
+
+	t.Run("partial degradation: change on known field only", func(t *testing.T) {
+		// Only VCP flips to Unknown; other fields stay known and unchanged.
+		// Expect: no change reported (VCP path skips Unknown, others equal).
+		partial := &Data{
+			Name:              "KATX",
+			VCP:               VCPUnknown,
+			Mode:              ModeUnknown,
+			Status:            "Online",
+			OperabilityStatus: "Normal",
+			PowerSource:       PowerSourceUtility,
+			GenState:          GenStateOff,
+		}
+
+		alertConfig := AlertConfig{
+			VCP:         true,
+			Status:      true,
+			Operability: true,
+			PowerSource: true,
+			GenState:    true,
+		}
+
+		changed, message := CompareData(oldData, partial, alertConfig)
+		if changed {
+			t.Errorf("Expected no change for partial degradation (VCP→Unknown, others stable), got changed=true message=%q", message)
+		}
+	})
+
 	t.Run("ignores disabled alerts", func(t *testing.T) {
 		newData := &Data{
 			Name:              "KATX",

--- a/dras/internal/radar/interfaces.go
+++ b/dras/internal/radar/interfaces.go
@@ -49,12 +49,12 @@ func (m *MockDataFetcher) FetchData(stationID string) (*Data, error) {
 	// Default response if none set
 	return &Data{
 		Name:              stationID,
-		VCP:               "R31",
-		Mode:              "Clear Air",
-		Status:            "Online",
-		OperabilityStatus: "Normal",
-		PowerSource:       "Utility",
-		GenState:          "Off",
+		VCP:               VCPR31,
+		Mode:              ModeClearAir,
+		Status:            StatusOperate,
+		OperabilityStatus: OpStatusOnline,
+		PowerSource:       PowerSourceUtility,
+		GenState:          GenStateOff,
 	}, nil
 }
 

--- a/dras/internal/radar/radar.go
+++ b/dras/internal/radar/radar.go
@@ -10,42 +10,272 @@ import (
 	"github.com/jacaudi/nws/cmd/nws"
 )
 
-// ErrUnknownVCP is returned by GetMode/GetVCPInfo when the VCP code is empty
-// or not recognized. Callers can use errors.Is to detect this case and treat
-// it as a soft condition (use the returned fallback label, log a warning,
-// continue) rather than aborting station processing.
+// -----------------------------------------------------------------------------
+// Typed status fields
+//
+// Per go-standards.md §4.1 / §4.3, each discrete-value field on radar.Data is
+// a named string type. Constants declare the values we currently know; the
+// underlying string type still accepts arbitrary NWS-supplied values, so a
+// surprise input from the API is preserved verbatim for forensics rather than
+// being squashed into a generic "Unknown" bucket.
+//
+// The <Type>Unknown sentinel (always the literal string "Unknown") is the
+// canonical "missing / unparseable" value. It pairs with the comparator's
+// skip-Unknown logic in compare.go so a degraded poll never fires a spurious
+// change notification.
+// -----------------------------------------------------------------------------
+
+// VCP is a NEXRAD WSR-88D Volume Coverage Pattern code as reported by the NWS
+// radar metadata API.
+type VCP string
+
+const (
+	VCPR12     VCP = "R12"
+	VCPR31     VCP = "R31"
+	VCPR35     VCP = "R35"
+	VCPR112    VCP = "R112"
+	VCPR212    VCP = "R212"
+	VCPR215    VCP = "R215"
+	VCPUnknown VCP = "Unknown"
+)
+
+// String implements fmt.Stringer for log/notification interpolation.
+func (v VCP) String() string { return string(v) }
+
+// RadarMode is the coarse scan-strategy category derived from a VCP code.
+type RadarMode string
+
+const (
+	ModeClearAir      RadarMode = "Clear Air"
+	ModePrecipitation RadarMode = "Precipitation"
+	ModeUnknown       RadarMode = "Unknown"
+)
+
+func (m RadarMode) String() string { return string(m) }
+
+// RadarStatus is the RDA operational mode reported by NWS. Observed values
+// in production include "Operate" (the dominant value) and the four below.
+type RadarStatus string
+
+const (
+	StatusOperate        RadarStatus = "Operate"
+	StatusStandby        RadarStatus = "Standby"
+	StatusTest           RadarStatus = "Test"
+	StatusOfflineOperate RadarStatus = "Offline Operate"
+	StatusUnknown        RadarStatus = "Unknown"
+)
+
+func (s RadarStatus) String() string { return string(s) }
+
+// OperabilityStatus is the RDA health-summary string reported by NWS. The
+// "RDA - On-line" value indicates a fully healthy station; everything else
+// signals a degradation of some kind.
+type OperabilityStatus string
+
+const (
+	OpStatusOnline      OperabilityStatus = "RDA - On-line"
+	OpStatusMaintenance OperabilityStatus = "RDA - Maintenance Action Mandatory"
+	OpStatusOffline     OperabilityStatus = "RDA - Off-line"
+	OpStatusStandby     OperabilityStatus = "RDA - Standby"
+	OpStatusCoasting    OperabilityStatus = "RDA - On-line / Coasting"
+	OpStatusUnknown     OperabilityStatus = "Unknown"
+)
+
+func (o OperabilityStatus) String() string { return string(o) }
+
+// PowerSource indicates whether the radar is running on utility power or its
+// backup generator.
+type PowerSource string
+
+const (
+	PowerSourceUtility   PowerSource = "Utility"
+	PowerSourceGenerator PowerSource = "Generator"
+	PowerSourceUnknown   PowerSource = "Unknown"
+)
+
+func (p PowerSource) String() string { return string(p) }
+
+// GeneratorState is the simplified On/Off interpretation of the NWS
+// pipe-separated generatorState field. See ParseGeneratorState for the
+// semantic rules.
+type GeneratorState string
+
+const (
+	GenStateOn      GeneratorState = "On"
+	GenStateOff     GeneratorState = "Off"
+	GenStateUnknown GeneratorState = "Unknown"
+)
+
+func (g GeneratorState) String() string { return string(g) }
+
+// -----------------------------------------------------------------------------
+// Sentinel errors — soft-fail signals for the typed parsers
+// -----------------------------------------------------------------------------
+
+// ErrUnknownVCP is returned by GetMode / GetVCPInfo when the VCP code is empty
+// or not in the catalog. Callers can use errors.Is to detect this case and
+// treat it as a soft condition: use the returned fallback value, log a
+// warning, continue. Aborting station processing on a single bad field would
+// stall the whole 5-minute poll cycle (issue #121, PR #123).
 var ErrUnknownVCP = errors.New("unknown VCP")
+
+// ErrUnknownGeneratorState is returned by ParseGeneratorState when the input
+// cannot be classified as On or Off. Caller treatment mirrors ErrUnknownVCP
+// (issue #129).
+var ErrUnknownGeneratorState = errors.New("unknown generator state")
+
+// -----------------------------------------------------------------------------
+// VCP catalog + lookups
+// -----------------------------------------------------------------------------
 
 // VCPInfo describes a NEXRAD WSR-88D Volume Coverage Pattern.
 type VCPInfo struct {
-	Mode        string // Coarse category: "Clear Air" or "Precipitation"
-	Description string // Human-readable detail about the scan pattern
-	AlertText   string // User-facing message used in change notifications
+	Mode        RadarMode // Coarse category: ModeClearAir or ModePrecipitation
+	Description string    // Human-readable detail about the scan pattern
+	AlertText   string    // User-facing message used in change notifications
 }
 
 // vcpCatalog maps VCP codes (as reported by the NWS radar metadata API) to
 // their coarse mode, a short description, and the alert text shown to users
 // when this VCP becomes active. Source: NOAA/NWS WSR-88D operations
 // documentation.
-var vcpCatalog = map[string]VCPInfo{
-	"R31":  {Mode: "Clear Air", Description: "Clear Air, long pulse (~10 min cycle, stratiform/biological targets)", AlertText: "Clear Air Mode Active"},
-	"R35":  {Mode: "Clear Air", Description: "Clear Air, short pulse with clutter mitigation (~7 min cycle)", AlertText: "Clear Air Mode Active"},
-	"R12":  {Mode: "Precipitation", Description: "Precipitation, rapid evolution (~4.2 min cycle, 14 elevations)", AlertText: "Precipitation Mode Active"},
-	"R112": {Mode: "Precipitation", Description: "Precipitation with MRLE (multi-PRF range-folding mitigation)", AlertText: "Precipitation Mode (Velocity Scanning Emphasis) Active"},
-	"R212": {Mode: "Precipitation", Description: "Precipitation with SAILS (~4.5 min cycle, common severe-weather VCP)", AlertText: "Precipitation Mode Active"},
-	"R215": {Mode: "Precipitation", Description: "Precipitation (~6 min cycle, 15 elevations, tropical/widespread)", AlertText: "Precipitation Mode (Vertical Scanning Emphasis) Active"},
+var vcpCatalog = map[VCP]VCPInfo{
+	VCPR31:  {Mode: ModeClearAir, Description: "Clear Air, long pulse (~10 min cycle, stratiform/biological targets)", AlertText: "Clear Air Mode Active"},
+	VCPR35:  {Mode: ModeClearAir, Description: "Clear Air, short pulse with clutter mitigation (~7 min cycle)", AlertText: "Clear Air Mode Active"},
+	VCPR12:  {Mode: ModePrecipitation, Description: "Precipitation, rapid evolution (~4.2 min cycle, 14 elevations)", AlertText: "Precipitation Mode Active"},
+	VCPR112: {Mode: ModePrecipitation, Description: "Precipitation with MRLE (multi-PRF range-folding mitigation)", AlertText: "Precipitation Mode (Velocity Scanning Emphasis) Active"},
+	VCPR212: {Mode: ModePrecipitation, Description: "Precipitation with SAILS (~4.5 min cycle, common severe-weather VCP)", AlertText: "Precipitation Mode Active"},
+	VCPR215: {Mode: ModePrecipitation, Description: "Precipitation (~6 min cycle, 15 elevations, tropical/widespread)", AlertText: "Precipitation Mode (Vertical Scanning Emphasis) Active"},
 }
 
-// Data represents the data for a radar.
-type Data struct {
-	Name              string // Name of the radar.
-	VCP               string // Volume Coverage Pattern of the radar.
-	Mode              string // Scanning mode of the radar.
-	Status            string // Status of the radar.
-	OperabilityStatus string // Operability Status of the radar.
-	PowerSource       string // Power source of the radar.
-	GenState          string // General state of the radar.
+// GetMode returns the radar mode for a given VCP code, looked up from
+// vcpCatalog.
+//
+// Unknown VCPs return ModeUnknown along with an error wrapping ErrUnknownVCP.
+// Callers should treat this as a soft condition: errors.Is(err, ErrUnknownVCP)
+// → use ModeUnknown and continue.
+func GetMode(vcp VCP) (RadarMode, error) {
+	if info, ok := vcpCatalog[vcp]; ok {
+		return info.Mode, nil
+	}
+	return ModeUnknown, fmt.Errorf("%w: %q", ErrUnknownVCP, string(vcp))
 }
+
+// GetVCPInfo returns the full catalog entry (mode + description + alert text)
+// for a VCP code. Unknown VCPs return a fallback VCPInfo and an error wrapping
+// ErrUnknownVCP, with the same soft-handle semantics as GetMode.
+func GetVCPInfo(vcp VCP) (VCPInfo, error) {
+	if info, ok := vcpCatalog[vcp]; ok {
+		return info, nil
+	}
+	fallback := VCPInfo{
+		Mode:        ModeUnknown,
+		Description: fmt.Sprintf("Unrecognized VCP code %q", string(vcp)),
+	}
+	return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, string(vcp))
+}
+
+// -----------------------------------------------------------------------------
+// Parse<X> constructors
+//
+// Each ParseX takes the raw NWS string and returns the typed value. For
+// Status, OperabilityStatus, and PowerSource the parser is a thin guard
+// against empty input — non-empty values pass through verbatim as the typed
+// string (preserving forensic detail when NWS surfaces a value we haven't
+// enumerated as a constant yet).
+//
+// VCP and Mode use catalog-based lookups (GetMode / GetVCPInfo).
+// GeneratorState requires semantic parsing — see ParseGeneratorState.
+// -----------------------------------------------------------------------------
+
+// ParseVCP wraps a raw VCP string in the VCP type, mapping the empty string
+// to VCPUnknown. Unknown non-empty codes pass through verbatim so the raw
+// value survives for forensic logging.
+func ParseVCP(s string) VCP {
+	if s == "" {
+		return VCPUnknown
+	}
+	return VCP(s)
+}
+
+// ParseRadarStatus wraps a raw status string in RadarStatus, mapping empty
+// input to StatusUnknown.
+func ParseRadarStatus(s string) RadarStatus {
+	if s == "" {
+		return StatusUnknown
+	}
+	return RadarStatus(s)
+}
+
+// ParseOperabilityStatus wraps a raw operability-status string in
+// OperabilityStatus, mapping empty input to OpStatusUnknown.
+func ParseOperabilityStatus(s string) OperabilityStatus {
+	if s == "" {
+		return OpStatusUnknown
+	}
+	return OperabilityStatus(s)
+}
+
+// ParsePowerSource wraps a raw power-source string in PowerSource, mapping
+// empty input to PowerSourceUnknown.
+func ParsePowerSource(s string) PowerSource {
+	if s == "" {
+		return PowerSourceUnknown
+	}
+	return PowerSource(s)
+}
+
+// ParseGeneratorState interprets the NWS pipe-separated generatorState field
+// into a simplified GeneratorState.
+//
+// Strategy: split on `|`, decide by token-set membership.
+//   - `Generator On` ∈ tokens  → GenStateOn
+//   - only token == `Utility PWR Available` → GenStateOff
+//   - anything else (including empty input) → GenStateUnknown plus an error
+//     wrapping ErrUnknownGeneratorState
+//
+// Returning an error on Unknown is deliberate so callers can choose between
+// soft-fail and abort via errors.Is — but the typed return is always usable.
+// The previous implementation returned ("", "unknown input") and the caller
+// aborted the whole 5-minute poll cycle (issue #129).
+func ParseGeneratorState(input string) (GeneratorState, error) {
+	if input == "" {
+		return GenStateUnknown, fmt.Errorf("%w: %q", ErrUnknownGeneratorState, input)
+	}
+	tokens := map[string]bool{}
+	for _, t := range strings.Split(input, "|") {
+		tokens[strings.TrimSpace(t)] = true
+	}
+	switch {
+	case tokens["Generator On"]:
+		return GenStateOn, nil
+	case tokens["Utility PWR Available"] && len(tokens) == 1:
+		return GenStateOff, nil
+	default:
+		return GenStateUnknown, fmt.Errorf("%w: %q", ErrUnknownGeneratorState, input)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Data
+// -----------------------------------------------------------------------------
+
+// Data represents the per-station radar metadata sampled from the NWS API.
+// Status fields are named string types so the compiler catches accidental
+// untyped-string usage and the const blocks above document the value space.
+type Data struct {
+	Name              string // Identifying metadata, not compared
+	VCP               VCP
+	Mode              RadarMode
+	Status            RadarStatus
+	OperabilityStatus OperabilityStatus
+	PowerSource       PowerSource
+	GenState          GeneratorState
+}
+
+// -----------------------------------------------------------------------------
+// Service
+// -----------------------------------------------------------------------------
 
 // Service handles radar data operations.
 type Service struct {
@@ -58,99 +288,61 @@ func New() *Service {
 }
 
 // FetchData retrieves radar data for a given station ID.
-// It returns a pointer to a Data struct and an error if any.
+//
+// Per-field soft-fail policy:
+//   - VCP / Mode: an empty or unrecognized VCP yields ModeUnknown and logs a
+//     warning; processing continues. (issue #121 / PR #123)
+//   - GeneratorState: an empty or unrecognized generatorState yields
+//     GenStateUnknown and logs a warning; processing continues. (issue #129)
+//   - Status / OperabilityStatus / PowerSource: empty input yields the
+//     XUnknown sentinel; non-empty values pass through as typed strings.
+//
+// This means a degraded NWS payload (missing fields) returns a populated
+// *Data with sentinels in the affected slots, rather than aborting the whole
+// poll. The comparator (CompareData) skips change notifications when the new
+// value of a tracked field equals its Unknown sentinel so degraded polls
+// produce silence, not spurious flips.
 func (s *Service) FetchData(stationID string) (*Data, error) {
 	radarResponse, err := nws.RadarStation(stationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get RADAR data for station %q: %w", stationID, err)
 	}
 
-	// Fetching radar VCP and determine mode. An empty or unrecognized VCP is
-	// not fatal: GetMode returns a "Unknown (VCP ...)" fallback label along
-	// with ErrUnknownVCP. We log a warning and continue so the rest of the
-	// station data (status, generator state, etc.) still gets processed.
-	radarVCPCode := radarResponse.RDA.Properties.VolumeCoveragePattern
-	radarMode, err := GetMode(radarVCPCode)
+	vcp := ParseVCP(radarResponse.RDA.Properties.VolumeCoveragePattern)
+	mode, err := GetMode(vcp)
 	if err != nil {
 		if !errors.Is(err, ErrUnknownVCP) {
 			return nil, err
 		}
-		slog.Warn("Unrecognized VCP, using fallback mode label", "station", stationID, "vcp", radarVCPCode, "mode", radarMode)
+		slog.Warn("Unrecognized VCP, using fallback mode label",
+			"station", stationID, "vcp", string(vcp), "mode", string(mode))
 	}
 
-	// Fetching radar VCP and determine mode
-	genStateResponse := radarResponse.RDA.Properties.GeneratorState
-	genStateStatement, err := simplifyGeneratorState(genStateResponse) // Converting generator state response to understandable text
+	genState, err := ParseGeneratorState(radarResponse.RDA.Properties.GeneratorState)
 	if err != nil {
-		return nil, err
-	}
-
-	// Constructing the Data structure with both VCP and human-readable translation
-	radarData := &Data{
-		Name:              radarResponse.Name,
-		VCP:               radarVCPCode,
-		Mode:              radarMode,
-		Status:            radarResponse.RDA.Properties.Status,
-		OperabilityStatus: radarResponse.RDA.Properties.OperabilityStatus,
-		PowerSource:       radarResponse.Performance.Properties.PowerSource,
-		GenState:          genStateStatement,
-	}
-
-	return radarData, nil
-}
-
-// GetMode returns the radar mode for a given VCP code, looked up from
-// vcpCatalog.
-//
-// If the VCP code is empty or not in the catalog, GetMode returns a fallback
-// label of the form `Unknown (VCP %q)` along with an error wrapping
-// ErrUnknownVCP. Callers should treat this as a soft condition:
-// errors.Is(err, ErrUnknownVCP) → use the fallback label and continue.
-func GetMode(vcp string) (string, error) {
-	if info, ok := vcpCatalog[vcp]; ok {
-		return info.Mode, nil
-	}
-	fallback := fmt.Sprintf("Unknown (VCP %q)", vcp)
-	return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, vcp)
-}
-
-// GetVCPInfo returns the full catalog entry (mode + description) for a VCP
-// code. Unknown VCPs return a fallback VCPInfo and an error wrapping
-// ErrUnknownVCP, with the same soft-handle semantics as GetMode.
-func GetVCPInfo(vcp string) (VCPInfo, error) {
-	if info, ok := vcpCatalog[vcp]; ok {
-		return info, nil
-	}
-	fallback := VCPInfo{
-		Mode:        fmt.Sprintf("Unknown (VCP %q)", vcp),
-		Description: fmt.Sprintf("Unrecognized VCP code %q", vcp),
-	}
-	return fallback, fmt.Errorf("%w: %q", ErrUnknownVCP, vcp)
-}
-
-// simplifyGeneratorState generates the simplified generator state based on the given input.
-// It takes a genInput string as input and returns the corresponding genState string and an error (if any).
-func simplifyGeneratorState(input string) (string, error) {
-	replacements := map[string]string{
-		"Switched to Auxiliary Power|Utility PWR Available|Generator On": "On",
-		"Switched to Auxiliary Power|Generator On":                       "On",
-		"Utility PWR Available|Generator On":                             "On",
-		"Utility PWR Available":                                          "Off",
-	}
-
-	for pattern, replacement := range replacements {
-		if input == pattern {
-			return replacement, nil
+		if !errors.Is(err, ErrUnknownGeneratorState) {
+			return nil, err
 		}
+		slog.Warn("Unrecognized generator state, using fallback label",
+			"station", stationID,
+			"input", radarResponse.RDA.Properties.GeneratorState,
+			"state", string(genState))
 	}
 
-	return "", errors.New("unknown input")
+	return &Data{
+		Name:              radarResponse.Name,
+		VCP:               vcp,
+		Mode:              mode,
+		Status:            ParseRadarStatus(radarResponse.RDA.Properties.Status),
+		OperabilityStatus: ParseOperabilityStatus(radarResponse.RDA.Properties.OperabilityStatus),
+		PowerSource:       ParsePowerSource(radarResponse.Performance.Properties.PowerSource),
+		GenState:          genState,
+	}, nil
 }
 
-// SanitizeStationIDs splits a string of station IDs by space, comma, or semicolon
-// and returns a slice of sanitized and validated station IDs.
+// SanitizeStationIDs splits a string of station IDs by space, comma, or
+// semicolon and returns a slice of sanitized and validated station IDs.
 func SanitizeStationIDs(stationInput string) []string {
-	// Define a regular expression to split by space, comma, or semicolon
 	re := regexp.MustCompile(`[ ,;]+`)
 	stationIDs := re.Split(stationInput, -1)
 
@@ -160,7 +352,6 @@ func SanitizeStationIDs(stationInput string) []string {
 		if trimmed == "" {
 			continue
 		}
-		// Convert to uppercase and validate format
 		trimmed = strings.ToUpper(trimmed)
 		if ValidateStationID(trimmed) {
 			validStations = append(validStations, trimmed)
@@ -169,18 +360,15 @@ func SanitizeStationIDs(stationInput string) []string {
 	return validStations
 }
 
-// ValidateStationID validates a radar station ID format
-// Station IDs should be 4 characters, starting with 'K' for US stations
+// ValidateStationID validates a radar station ID format. Station IDs should
+// be 4 characters, starting with 'K' for US stations; some non-K
+// international stations are also valid.
 func ValidateStationID(stationID string) bool {
 	if len(stationID) != 4 {
 		return false
 	}
 
-	// US radar stations typically start with 'K'
-	// Some exceptions exist but this covers 99% of cases
 	if !strings.HasPrefix(stationID, "K") {
-		// Allow some international stations or special cases
-		// But validate they are all uppercase letters
 		for _, char := range stationID {
 			if char < 'A' || char > 'Z' {
 				return false
@@ -188,7 +376,6 @@ func ValidateStationID(stationID string) bool {
 		}
 	}
 
-	// Validate all characters are uppercase letters
 	for _, char := range stationID {
 		if char < 'A' || char > 'Z' {
 			return false

--- a/dras/internal/radar/radar_test.go
+++ b/dras/internal/radar/radar_test.go
@@ -2,27 +2,27 @@ package radar
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
 
 func TestGetMode(t *testing.T) {
 	tests := []struct {
-		name           string
-		vcp            string
-		expectedMode   string
-		expectUnknown  bool
-		fallbackSubstr string
+		name          string
+		vcp           VCP
+		expectedMode  RadarMode
+		expectUnknown bool
 	}{
-		{name: "R31", vcp: "R31", expectedMode: "Clear Air"},
-		{name: "R35", vcp: "R35", expectedMode: "Clear Air"},
-		{name: "R12", vcp: "R12", expectedMode: "Precipitation"},
-		{name: "R112", vcp: "R112", expectedMode: "Precipitation"},
-		{name: "R212", vcp: "R212", expectedMode: "Precipitation"},
-		{name: "R215", vcp: "R215", expectedMode: "Precipitation"},
-		{name: "unknown_R99", vcp: "R99", expectUnknown: true, fallbackSubstr: `"R99"`},
-		{name: "empty", vcp: "", expectUnknown: true, fallbackSubstr: `""`},
-		{name: "whitespace", vcp: " ", expectUnknown: true, fallbackSubstr: `" "`},
+		{name: "R31", vcp: VCPR31, expectedMode: ModeClearAir},
+		{name: "R35", vcp: VCPR35, expectedMode: ModeClearAir},
+		{name: "R12", vcp: VCPR12, expectedMode: ModePrecipitation},
+		{name: "R112", vcp: VCPR112, expectedMode: ModePrecipitation},
+		{name: "R212", vcp: VCPR212, expectedMode: ModePrecipitation},
+		{name: "R215", vcp: VCPR215, expectedMode: ModePrecipitation},
+		{name: "unknown_R99", vcp: "R99", expectUnknown: true},
+		{name: "empty", vcp: "", expectUnknown: true},
+		{name: "whitespace", vcp: " ", expectUnknown: true},
 	}
 
 	for _, tt := range tests {
@@ -33,11 +33,8 @@ func TestGetMode(t *testing.T) {
 				if !errors.Is(err, ErrUnknownVCP) {
 					t.Fatalf("expected ErrUnknownVCP for VCP %q, got %v", tt.vcp, err)
 				}
-				if !strings.Contains(mode, "Unknown") {
-					t.Errorf("expected fallback mode label to contain \"Unknown\" for VCP %q, got %q", tt.vcp, mode)
-				}
-				if !strings.Contains(mode, tt.fallbackSubstr) {
-					t.Errorf("expected fallback mode label to contain %s for VCP %q, got %q", tt.fallbackSubstr, tt.vcp, mode)
+				if mode != ModeUnknown {
+					t.Errorf("expected ModeUnknown for VCP %q, got %q", tt.vcp, mode)
 				}
 				return
 			}
@@ -56,12 +53,12 @@ func TestGetMode(t *testing.T) {
 
 func TestGetVCPInfo(t *testing.T) {
 	t.Run("known", func(t *testing.T) {
-		info, err := GetVCPInfo("R212")
+		info, err := GetVCPInfo(VCPR212)
 		if err != nil {
 			t.Fatalf("unexpected error for R212: %v", err)
 		}
-		if info.Mode != "Precipitation" {
-			t.Errorf("Mode = %q, want %q", info.Mode, "Precipitation")
+		if info.Mode != ModePrecipitation {
+			t.Errorf("Mode = %q, want %q", info.Mode, ModePrecipitation)
 		}
 		if !strings.Contains(info.Description, "SAILS") {
 			t.Errorf("Description = %q, expected to mention SAILS", info.Description)
@@ -73,8 +70,8 @@ func TestGetVCPInfo(t *testing.T) {
 		if !errors.Is(err, ErrUnknownVCP) {
 			t.Fatalf("expected ErrUnknownVCP, got %v", err)
 		}
-		if !strings.Contains(info.Mode, "Unknown") {
-			t.Errorf("Mode = %q, expected to contain \"Unknown\"", info.Mode)
+		if info.Mode != ModeUnknown {
+			t.Errorf("Mode = %q, expected ModeUnknown", info.Mode)
 		}
 		if !strings.Contains(info.Description, "R999") {
 			t.Errorf("Description = %q, expected to contain raw VCP %q", info.Description, "R999")
@@ -146,38 +143,58 @@ func TestValidateStationID(t *testing.T) {
 	}
 }
 
-func TestSimplifyGeneratorState(t *testing.T) {
+func TestParseGeneratorState(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected string
-		hasError bool
+		name        string
+		input       string
+		want        GeneratorState
+		expectError bool
 	}{
-		{"Switched to Auxiliary Power|Utility PWR Available|Generator On", "On", false},
-		{"Switched to Auxiliary Power|Generator On", "On", false},
-		{"Utility PWR Available|Generator On", "On", false},
-		{"Utility PWR Available", "Off", false},
-		{"Unknown State", "", true},
+		// Known good — all four canonical raw strings collapse to On / Off.
+		{name: "all_three_tokens_with_generator_on", input: "Switched to Auxiliary Power|Utility PWR Available|Generator On", want: GenStateOn},
+		{name: "aux_power_plus_generator_on", input: "Switched to Auxiliary Power|Generator On", want: GenStateOn},
+		{name: "utility_plus_generator_on", input: "Utility PWR Available|Generator On", want: GenStateOn},
+		{name: "utility_only", input: "Utility PWR Available", want: GenStateOff},
+
+		// Token-set robustness — order shouldn't matter (Option 3 logic).
+		{name: "reversed_order", input: "Generator On|Utility PWR Available", want: GenStateOn},
+
+		// Soft-fail surface area — empty + novel + ambiguous inputs land on
+		// GenStateUnknown with ErrUnknownGeneratorState wrapping. This is the
+		// regression coverage for issue #129; the previous implementation
+		// returned ("", errors.New("unknown input")) and the caller aborted.
+		{name: "empty", input: "", want: GenStateUnknown, expectError: true},
+		{name: "totally_novel", input: "Cold Fusion Reactor Active", want: GenStateUnknown, expectError: true},
+		// Utility token present but with extra unknown tokens → not safe to
+		// classify as Off (might mean "running on generator but also..."),
+		// so soft-fail.
+		{name: "utility_with_extra_tokens", input: "Utility PWR Available|Mystery State", want: GenStateUnknown, expectError: true},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result, err := simplifyGeneratorState(tt.input)
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGeneratorState(tt.input)
 
-			if tt.hasError {
-				if err == nil {
-					t.Errorf("Expected error for input %q, but got none", tt.input)
-				}
-				return
+			if got != tt.want {
+				t.Errorf("ParseGeneratorState(%q) state = %q, want %q", tt.input, got, tt.want)
 			}
 
-			if err != nil {
-				t.Errorf("Unexpected error for input %q: %v", tt.input, err)
-				return
-			}
-
-			if result != tt.expected {
-				t.Errorf("For input %q, expected %q, got %q", tt.input, tt.expected, result)
+			switch {
+			case tt.expectError && !errors.Is(err, ErrUnknownGeneratorState):
+				t.Errorf("ParseGeneratorState(%q) err = %v, want errors.Is(err, ErrUnknownGeneratorState)", tt.input, err)
+			case !tt.expectError && err != nil:
+				t.Errorf("ParseGeneratorState(%q) unexpected err = %v", tt.input, err)
 			}
 		})
 	}
+}
+
+// ExampleParseGeneratorState documents the typical happy-path call shape and
+// is exercised by `go test` so the example never rots (§8.3 of
+// go-standards.md: "A broken example is a broken release.").
+func ExampleParseGeneratorState() {
+	state, _ := ParseGeneratorState("Utility PWR Available|Generator On")
+	// state implements fmt.Stringer; %s prints the underlying string.
+	fmt.Println(state)
+	// Output: On
 }


### PR DESCRIPTION
## Summary

Fixes #129. Refactors `radar.Data`'s discrete-value fields onto named string types per [go-standards.md](file:///Users/acaudill/.config/reference/go-standards.md) §4.1/§4.3, and replaces `simplifyGeneratorState` with a soft-failing `ParseGeneratorState` so a degraded NWS payload no longer aborts the 5-minute poll cycle.

Combines Option 5 (typed enums + comparator skip-Unknown) and Option E (symmetric refactor of all status fields) from the design discussion. Option 2's sentinel-error pattern is folded into `ParseGeneratorState`, and Option 3's token-set parsing lives inside it so the soft-fail is rare in practice.

## Changes

### Typed enums (§4.1 / §4.3)

Six named string types with const blocks, `Stringer` methods, and `<Type>Unknown` sentinels:

| Type | Knowns | Sentinel |
|---|---|---|
| `VCP` | `VCPR12 / R31 / R35 / R112 / R212 / R215` | `VCPUnknown` |
| `RadarMode` | `ModeClearAir`, `ModePrecipitation` | `ModeUnknown` |
| `RadarStatus` | `StatusOperate / Standby / Test / OfflineOperate` | `StatusUnknown` |
| `OperabilityStatus` | `OpStatusOnline / Maintenance / Offline / Standby / Coasting` | `OpStatusUnknown` |
| `PowerSource` | `PowerSourceUtility / Generator` | `PowerSourceUnknown` |
| `GeneratorState` | `GenStateOn / Off` | `GenStateUnknown` |

The underlying string type still accepts arbitrary NWS-supplied values — a surprise input is preserved verbatim for forensic logging rather than squashed into the Unknown bucket. Const blocks document the value space we've actually observed in the wild (per the [API survey](docs/research/2026-05-17-nws-radar-station-api-fields.md), though that doc isn't committed in this branch).

### `Parse<X>` constructors

  - `ParseVCP` / `ParseRadarStatus` / `ParseOperabilityStatus` / `ParsePowerSource` — empty input → `<Type>Unknown`, non-empty passes through verbatim. No error possible.
  - `ParseGeneratorState` — semantic token-set parser. `Generator On` ∈ pipe-tokens → `GenStateOn`; only `Utility PWR Available` → `GenStateOff`; everything else (including empty) → `GenStateUnknown` plus an error wrapping `ErrUnknownGeneratorState`.

### `FetchData` soft-fail (the actual #129 fix)

Mirrors the `ErrUnknownVCP` shape from #121 (PR #123). When `ParseGeneratorState` reports `ErrUnknownGeneratorState`, `FetchData` logs at WARN with the raw input + station ID and continues with `GenState = GenStateUnknown`. The previous implementation returned `("", "unknown input")` and the caller aborted the entire poll — three of five aborted polls observed in v2.13.1 production logs over 8 days hit that path.

### Comparator skip-Unknown

`CompareData` now skips reporting a flip when the **new** value equals the field's Unknown sentinel. `monitor.processStation` only updates the cache when `changed=true`, so a degraded poll leaves the cache holding the last known-good value; recovery to the same value produces a true no-change. One-sided by design — `Unknown→OK` on recovery still fires (genuine state-clarification, not noise).

## Tests

  - **`TestParseGeneratorState`** — table-driven. Covers all four canonical raw strings, token-order robustness, and three fallthrough cases (empty, totally novel, ambiguous) with `errors.Is(err, ErrUnknownGeneratorState)` assertions.
  - **`ExampleParseGeneratorState`** — §8.3 testable example, output-checked.
  - **`TestCompareData`** gains three sub-tests for skip-Unknown:
    - `skips flip to Unknown on every field` — full degraded payload, expect zero notifications
    - `flip FROM Unknown is reported (recovery)` — first-run-with-degraded-data recovery still fires
    - `partial degradation: change on known field only` — VCP→Unknown alone with other fields stable produces no notification
  - **`TestGetMode` / `TestGetVCPInfo`** updated to use the new typed values.
  - **`MockDataFetcher`** default response uses the new constants.

`go test ./...` green across all 9 packages; `go vet ./...` clean.

## Notes

  - `Data.Name` remains `string` (identifying metadata, not a status).
  - `simplifyGeneratorState` (lowercase, package-private) is removed in favor of `ParseGeneratorState`. No external callers used the old name.
  - `monitor.go` needed no changes — `Mode` interpolation goes through `%s` (Stringer) and `VCP` equality is type-preserving.

## Test plan

- [x] `go test ./...` — all 9 packages pass
- [x] `go vet ./...` clean
- [x] Comparator unit tests cover skip-Unknown happy + recovery paths
- [x] `ExampleParseGeneratorState` round-trips through `go test`
- [ ] Deploy to Talos `selfhosted` and confirm no spurious notifications on next NWS-degraded-payload event (validation pending real-world recurrence; this is the same failure mode that hit 5 times in 8 days on v2.13.1)

Closes #129. Future symmetric extension targets — `alarmSummary` from #128, plus `controlStatus`, `superResolutionStatus`, and the `performance.properties.*` encoder-light fields — can layer onto this same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)