### PR TITLE
feat(radar): track alarmSummary as an alertable field

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ Each governs whether a change in that field triggers a notification.
 | `ALERT_VCP` | `true` | Volume Coverage Pattern change (clear-air ↔ precipitation, etc.). |
 | `ALERT_STATUS` | `false` | Operational status change. |
 | `ALERT_OPERABILITY` | `false` | Operability status change. |
+| `ALERT_ALARM_SUMMARY` | `false` | Alarm-summary change (which subsystem is alarming, e.g. `No Alarms` ↔ `Communication`). |
 | `ALERT_POWER_SOURCE` | `false` | Power-source change (utility ↔ generator). |
 | `ALERT_GEN_STATE` | `false` | Generator-state change. |
 

--- a/dras/internal/config/config.go
+++ b/dras/internal/config/config.go
@@ -80,6 +80,11 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
+	cfg.AlertConfig.AlarmSummary, err = parseBoolEnv("ALERT_ALARM_SUMMARY", "false")
+	if err != nil {
+		return nil, err
+	}
+
 	cfg.AlertConfig.PowerSource, err = parseBoolEnv("ALERT_POWER_SOURCE", "false")
 	if err != nil {
 		return nil, err
@@ -273,6 +278,9 @@ func (c *Config) String() string {
 	}
 	if c.AlertConfig.Operability {
 		alertTypes = append(alertTypes, "Operability")
+	}
+	if c.AlertConfig.AlarmSummary {
+		alertTypes = append(alertTypes, "AlarmSummary")
 	}
 	if c.AlertConfig.PowerSource {
 		alertTypes = append(alertTypes, "PowerSource")

--- a/dras/internal/config/config_test.go
+++ b/dras/internal/config/config_test.go
@@ -20,6 +20,7 @@ func TestLoad(t *testing.T) {
 		"ALERT_VCP",
 		"ALERT_STATUS",
 		"ALERT_OPERABILITY",
+		"ALERT_ALARM_SUMMARY",
 		"ALERT_POWER_SOURCE",
 		"ALERT_GEN_STATE",
 		"RADAR_IMAGE_ENABLED",
@@ -136,6 +137,42 @@ func TestLoad(t *testing.T) {
 		}
 		if !cfg.AlertConfig.Status {
 			t.Errorf("Expected Status alerts to be true")
+		}
+	})
+
+	// Integration coverage for the ALERT_ALARM_SUMMARY env var (issue #128):
+	// defaults off, opt-in via env, and rejects a non-bool value.
+	t.Run("ALERT_ALARM_SUMMARY defaults to false", func(t *testing.T) {
+		clearEnv(t)
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if cfg.AlertConfig.AlarmSummary {
+			t.Error("Expected AlarmSummary alerts to be false by default")
+		}
+	})
+
+	t.Run("ALERT_ALARM_SUMMARY opt-in via env", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("ALERT_ALARM_SUMMARY", "true")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if !cfg.AlertConfig.AlarmSummary {
+			t.Error("Expected AlarmSummary alerts to be true when ALERT_ALARM_SUMMARY=true")
+		}
+	})
+
+	t.Run("handles invalid ALERT_ALARM_SUMMARY value", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("ALERT_ALARM_SUMMARY", "maybe")
+
+		if _, err := Load(); err == nil {
+			t.Error("Expected error for invalid ALERT_ALARM_SUMMARY value")
 		}
 	})
 

--- a/dras/internal/radar/alarm_summary_categories_test.go
+++ b/dras/internal/radar/alarm_summary_categories_test.go
@@ -1,0 +1,85 @@
+package radar
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file gathers the remaining test categories for the alarmSummary
+// feature (issue #128) that don't have a natural home in the existing
+// per-function test files: Security, Retry, and Frame. The Unit,
+// Functional, Performance, and Integration categories live alongside their
+// subjects (radar_test.go, compare_test.go, benchmark_test.go,
+// config_test.go / integration_test.go respectively).
+
+// --- Security -------------------------------------------------------------
+//
+// The parser preserves NWS-supplied values verbatim rather than squashing
+// them, so it must not panic, truncate, or otherwise transform adversarial
+// input. alarmSummary is a text-only field that flows into a notification
+// message; there is no interpolation into a query/template beyond fmt, so
+// the security contract here is "faithful, non-crashing pass-through".
+func TestParseAlarmSummary_Security_VerbatimPassthrough(t *testing.T) {
+	adversarial := []string{
+		"Communication\n\rInjected: line", // CR/LF injection attempt
+		strings.Repeat("A", 8192),         // oversized value
+		"'; DROP TABLE alarms;--",         // SQL-ish payload (no DB, but prove pass-through)
+		"{{.Secret}}",                     // Go-template-looking payload
+		"No Alarms\x00Communication",      // embedded NUL
+		"⚠️ 警報 alarme",                    // multibyte / emoji
+	}
+
+	for _, in := range adversarial {
+		got := ParseAlarmSummary(in)
+		if string(got) != in {
+			t.Errorf("ParseAlarmSummary(%q) = %q, want verbatim pass-through", in, string(got))
+		}
+	}
+}
+
+// --- Retry ----------------------------------------------------------------
+//
+// N/A placeholder. This feature adds no new external call: alarmSummary is
+// read from the *already-fetched* radarResponse inside Service.FetchData, so
+// it rides on the single existing nws.RadarStation() request. Retry/backoff
+// for that upstream fetch lives in the nws client and internal/httpretry and
+// is unchanged by this feature. ParseAlarmSummary and CompareData are pure,
+// in-memory, and deterministic — there is nothing to retry. This test
+// documents that contract by asserting the parser is side-effect-free and
+// idempotent across repeated calls.
+func TestParseAlarmSummary_Retry_NoExternalCall(t *testing.T) {
+	const in = "Communication"
+	first := ParseAlarmSummary(in)
+	for i := 0; i < 5; i++ {
+		if got := ParseAlarmSummary(in); got != first {
+			t.Fatalf("ParseAlarmSummary is not idempotent: call %d = %q, want %q", i, got, first)
+		}
+	}
+}
+
+// --- Frame ----------------------------------------------------------------
+//
+// Builds & runs: exercise the whole alarmSummary path end-to-end in one
+// frame — parse two raw NWS strings into Data, run them through the real
+// CompareData comparator with the toggle on, and assert the exact
+// user-facing message. If the wiring (type, Data field, comparator block)
+// is broken this fails to compile or fails the assertion.
+func TestAlarmSummary_Frame_EndToEnd(t *testing.T) {
+	oldData := &Data{
+		Name:         "KATX",
+		AlarmSummary: ParseAlarmSummary("No Alarms"),
+	}
+	newData := &Data{
+		Name:         "KATX",
+		AlarmSummary: ParseAlarmSummary("Communication"),
+	}
+
+	changed, message := CompareData(oldData, newData, AlertConfig{AlarmSummary: true})
+	if !changed {
+		t.Fatal("Frame: expected alarm-summary change to be detected end-to-end")
+	}
+	const want = "Alarm summary changed from No Alarms to Communication"
+	if message != want {
+		t.Errorf("Frame: message = %q, want %q", message, want)
+	}
+}

--- a/dras/internal/radar/benchmark_test.go
+++ b/dras/internal/radar/benchmark_test.go
@@ -68,6 +68,17 @@ func BenchmarkCompareData(b *testing.B) {
 	}
 }
 
+// BenchmarkParseAlarmSummary is the performance coverage for the alarmSummary
+// parser (issue #128). It should be allocation-free for the pass-through path
+// since the parser only converts a string to a named string type.
+func BenchmarkParseAlarmSummary(b *testing.B) {
+	inputs := []string{"No Alarms", "Communication", "RDA Control", "", "Pedestal"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ParseAlarmSummary(inputs[i%len(inputs)])
+	}
+}
+
 // BenchmarkConcurrentRadarProcessing simulates concurrent radar data processing
 func BenchmarkConcurrentRadarProcessing(b *testing.B) {
 	stationIDs := []string{"KATX", "KRAX", "KBGM", "KTLX", "KFFC"}

--- a/dras/internal/radar/compare.go
+++ b/dras/internal/radar/compare.go
@@ -8,11 +8,12 @@ import (
 
 // AlertConfig holds configuration for which events to alert on.
 type AlertConfig struct {
-	VCP         bool
-	Status      bool
-	Operability bool
-	PowerSource bool
-	GenState    bool
+	VCP          bool
+	Status       bool
+	Operability  bool
+	AlarmSummary bool
+	PowerSource  bool
+	GenState     bool
 }
 
 // CompareData compares old and new radar data and returns whether any
@@ -57,6 +58,10 @@ func CompareData(oldData, newData *Data, alertConfig AlertConfig) (bool, string)
 
 	if alertConfig.Operability && newData.OperabilityStatus != OpStatusUnknown && oldData.OperabilityStatus != newData.OperabilityStatus {
 		changes = append(changes, fmt.Sprintf("Radar operability changed from %s to %s", oldData.OperabilityStatus, newData.OperabilityStatus))
+	}
+
+	if alertConfig.AlarmSummary && newData.AlarmSummary != AlarmSummaryUnknown && oldData.AlarmSummary != newData.AlarmSummary {
+		changes = append(changes, fmt.Sprintf("Alarm summary changed from %s to %s", oldData.AlarmSummary, newData.AlarmSummary))
 	}
 
 	if alertConfig.PowerSource && newData.PowerSource != PowerSourceUnknown && oldData.PowerSource != newData.PowerSource {

--- a/dras/internal/radar/compare_test.go
+++ b/dras/internal/radar/compare_test.go
@@ -268,6 +268,52 @@ func TestCompareData(t *testing.T) {
 		}
 	})
 
+	// Functional coverage for the alarmSummary field (issue #128). Same shape
+	// as the existing five comparators: fire on a real flip, stay silent on a
+	// flip to the Unknown sentinel, and honor the enable toggle.
+	t.Run("alarm summary change", func(t *testing.T) {
+		newData := &Data{
+			Name:              "KATX",
+			VCP:               "R31",
+			Mode:              "Clear Air",
+			Status:            "Online",
+			OperabilityStatus: "Normal",
+			AlarmSummary:      AlarmSummaryCommunication,
+			PowerSource:       "Utility",
+			GenState:          "Off",
+		}
+
+		alertConfig := AlertConfig{AlarmSummary: true}
+
+		changed, message := CompareData(oldData, newData, alertConfig)
+		if !changed {
+			t.Error("Expected alarm-summary change to be detected")
+		}
+		if !strings.Contains(message, "Alarm summary changed from  to Communication") {
+			t.Errorf("Expected alarm-summary change message, got %q", message)
+		}
+	})
+
+	t.Run("alarm summary skips flip to Unknown", func(t *testing.T) {
+		base := &Data{Name: "KATX", AlarmSummary: AlarmSummaryNone}
+		degraded := &Data{Name: "KATX", AlarmSummary: AlarmSummaryUnknown}
+
+		changed, message := CompareData(base, degraded, AlertConfig{AlarmSummary: true})
+		if changed {
+			t.Errorf("Expected no change for alarm-summary flip to Unknown, got message=%q", message)
+		}
+	})
+
+	t.Run("alarm summary respects disabled toggle", func(t *testing.T) {
+		base := &Data{Name: "KATX", AlarmSummary: AlarmSummaryNone}
+		alarming := &Data{Name: "KATX", AlarmSummary: AlarmSummaryCommunication}
+
+		changed, _ := CompareData(base, alarming, AlertConfig{AlarmSummary: false})
+		if changed {
+			t.Error("Expected no change when ALERT_ALARM_SUMMARY is off")
+		}
+	})
+
 	t.Run("ignores disabled alerts", func(t *testing.T) {
 		newData := &Data{
 			Name:              "KATX",

--- a/dras/internal/radar/integration_test.go
+++ b/dras/internal/radar/integration_test.go
@@ -49,6 +49,12 @@ func TestRealNWSIntegration(t *testing.T) {
 					t.Errorf("Expected status for %s, got empty string", stationID)
 				}
 
+				// alarmSummary always parses to at least AlarmSummaryUnknown,
+				// so the field must never be empty (issue #128).
+				if data.AlarmSummary == "" {
+					t.Errorf("Expected alarm summary for %s, got empty string (want a value or %q)", stationID, AlarmSummaryUnknown)
+				}
+
 				// Test that VCP can be converted to mode
 				mode, err := GetMode(data.VCP)
 				if err != nil {
@@ -59,8 +65,8 @@ func TestRealNWSIntegration(t *testing.T) {
 					}
 				}
 
-				t.Logf("Station %s: Name=%s, VCP=%s, Mode=%s, Status=%s, PowerSource=%s",
-					stationID, data.Name, data.VCP, data.Mode, data.Status, data.PowerSource)
+				t.Logf("Station %s: Name=%s, VCP=%s, Mode=%s, Status=%s, AlarmSummary=%s, PowerSource=%s",
+					stationID, data.Name, data.VCP, data.Mode, data.Status, data.AlarmSummary, data.PowerSource)
 			})
 		}
 	})

--- a/dras/internal/radar/radar.go
+++ b/dras/internal/radar/radar.go
@@ -83,6 +83,23 @@ const (
 
 func (o OperabilityStatus) String() string { return string(o) }
 
+// AlarmSummary is the RDA alarm-summary string reported by NWS. It is the
+// finest-grained of the three health fields (status / operabilityStatus /
+// alarmSummary): where operabilityStatus flags THAT something is wrong,
+// alarmSummary names WHICH subsystem. Observed values include "No Alarms"
+// (the healthy value), "Communication", "RDA Control", "Tower / Utilities".
+type AlarmSummary string
+
+const (
+	AlarmSummaryNone          AlarmSummary = "No Alarms"
+	AlarmSummaryCommunication AlarmSummary = "Communication"
+	AlarmSummaryRDAControl    AlarmSummary = "RDA Control"
+	AlarmSummaryTowerUtil     AlarmSummary = "Tower / Utilities"
+	AlarmSummaryUnknown       AlarmSummary = "Unknown"
+)
+
+func (a AlarmSummary) String() string { return string(a) }
+
 // PowerSource indicates whether the radar is running on utility power or its
 // backup generator.
 type PowerSource string
@@ -216,6 +233,16 @@ func ParseOperabilityStatus(s string) OperabilityStatus {
 	return OperabilityStatus(s)
 }
 
+// ParseAlarmSummary wraps a raw alarm-summary string in AlarmSummary, mapping
+// empty input to AlarmSummaryUnknown. Non-empty values pass through verbatim
+// so an unenumerated NWS value survives for forensic logging.
+func ParseAlarmSummary(s string) AlarmSummary {
+	if s == "" {
+		return AlarmSummaryUnknown
+	}
+	return AlarmSummary(s)
+}
+
 // ParsePowerSource wraps a raw power-source string in PowerSource, mapping
 // empty input to PowerSourceUnknown.
 func ParsePowerSource(s string) PowerSource {
@@ -269,6 +296,7 @@ type Data struct {
 	Mode              RadarMode
 	Status            RadarStatus
 	OperabilityStatus OperabilityStatus
+	AlarmSummary      AlarmSummary
 	PowerSource       PowerSource
 	GenState          GeneratorState
 }
@@ -335,6 +363,7 @@ func (s *Service) FetchData(stationID string) (*Data, error) {
 		Mode:              mode,
 		Status:            ParseRadarStatus(radarResponse.RDA.Properties.Status),
 		OperabilityStatus: ParseOperabilityStatus(radarResponse.RDA.Properties.OperabilityStatus),
+		AlarmSummary:      ParseAlarmSummary(radarResponse.RDA.Properties.AlarmSummary),
 		PowerSource:       ParsePowerSource(radarResponse.Performance.Properties.PowerSource),
 		GenState:          genState,
 	}, nil

--- a/dras/internal/radar/radar_test.go
+++ b/dras/internal/radar/radar_test.go
@@ -189,6 +189,34 @@ func TestParseGeneratorState(t *testing.T) {
 	}
 }
 
+// TestParseAlarmSummary is the unit coverage for the alarmSummary parser
+// (issue #128). Empty input maps to AlarmSummaryUnknown (the skip-Unknown
+// sentinel); every non-empty value passes through verbatim so an
+// unenumerated NWS value survives for forensic logging.
+func TestParseAlarmSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  AlarmSummary
+	}{
+		{name: "empty_maps_to_unknown", input: "", want: AlarmSummaryUnknown},
+		{name: "healthy", input: "No Alarms", want: AlarmSummaryNone},
+		{name: "communication", input: "Communication", want: AlarmSummaryCommunication},
+		{name: "rda_control", input: "RDA Control", want: AlarmSummaryRDAControl},
+		{name: "tower_utilities", input: "Tower / Utilities", want: AlarmSummaryTowerUtil},
+		// Unenumerated value passes through verbatim (not squashed to Unknown).
+		{name: "novel_value_passthrough", input: "Pedestal", want: AlarmSummary("Pedestal")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseAlarmSummary(tt.input); got != tt.want {
+				t.Errorf("ParseAlarmSummary(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // ExampleParseGeneratorState documents the typical happy-path call shape and
 // is exercised by `go test` so the example never rots (§8.3 of
 // go-standards.md: "A broken example is a broken release.").


### PR DESCRIPTION
## Summary

Implements the maintainer's 5-step sketch from #128: adds the NWS RDA `alarmSummary` health field to the radar monitor so operators can opt in to notifications when the alarming subsystem changes (e.g. `No Alarms` → `Communication`), alongside the existing five fields. `alarmSummary` is the finest-grained of the three health strings — it names *which* subsystem is alarming, not just *that* something is wrong.

## Changes

- **`internal/radar/radar.go`** — new `AlarmSummary` named-string type + value constants, `ParseAlarmSummary` (empty → `AlarmSummaryUnknown`, non-empty verbatim), `AlarmSummary` field on `radar.Data`, populated in `FetchData` from `radarResponse.RDA.Properties.AlarmSummary`. That field is already exposed by `jacaudi/nws@v0.1.0`, so no upstream PR was needed.
- **`internal/radar/compare.go`** — `AlarmSummary bool` on `AlertConfig` and a skip-Unknown comparator block (same shape as the other five), emitting `Alarm summary changed from X to Y`.
- **`internal/config/config.go`** — `ALERT_ALARM_SUMMARY` env wired via `parseBoolEnv(..., "false")` (default off, matching the other health fields) plus the `String()` summary.
- **`docs/configuration.md`** — documents the new env var.

The change is text-only and does not touch the renderer/image path — it rides on the single existing `nws.RadarStation()` fetch and `attachmentForChange` still gates images on `vcpChanged` only, so no-change polls still skip the image source.

## Acceptance (from the issue)

- [x] `radar.Data.AlarmSummary` populated from the API
- [x] `AlertConfig.AlarmSummary` toggleable via `ALERT_ALARM_SUMMARY`
- [x] Notification reads `Alarm summary changed from X to Y` on flip
- [x] Existing five comparators untouched
- [x] No renderer-call regression (no new external call added)

## Test categories

- **Unit** — `TestParseAlarmSummary` (empty→Unknown, verbatim pass-through, all constants).
- **Functional** — `TestCompareData` subtests: change fires, flip-to-Unknown skipped, disabled-toggle respected.
- **Performance** — `BenchmarkParseAlarmSummary` (0 allocs/op).
- **Integration** — `TestLoad` env-parse cases (default off / opt-in / invalid) + `alarmSummary` non-empty assertion in the real-NWS integration test.
- **Security** — `TestParseAlarmSummary_Security_VerbatimPassthrough` (CR/LF, oversized, NUL, template/SQL-ish, multibyte input preserved without panic/truncation).
- **Retry** — `TestParseAlarmSummary_Retry_NoExternalCall` (N/A placeholder + comment: no new external call; parser is pure/idempotent, upstream retry lives in the nws client / `httpretry`, unchanged).
- **Frame** — `TestAlarmSummary_Frame_EndToEnd` (parse → compare → exact message).

`go build ./... && go vet ./... && go test ./...` all green (module root is `dras/`); `gofmt` clean.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)