### PR TITLE
fix(chart): writable cartopy cache mount + raised renderer memory

### DIFF
--- a/chart/tests/mode_advanced_test.yaml
+++ b/chart/tests/mode_advanced_test.yaml
@@ -127,3 +127,41 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsUser
           value: 65532
+
+  # issue #125 — writable Cartopy cache so a cache miss self-heals instead of
+  # 500ing with PermissionError under the read-only baked cache + uid 65532.
+  - it: renderer sidecar mounts a writable Cartopy cache
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: /home/renderer/.local/share/cartopy
+            name: cartopy-cache
+
+  - it: pod-scoped emptyDir volume backs the Cartopy cache mount
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cartopy-cache
+            emptyDir:
+              sizeLimit: 256Mi
+
+  # issue #125 — raised renderer memory to stop ~4h OOMKills over multi-day runs.
+  - it: renderer sidecar has raised memory (3Gi limit, 1Gi request)
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 3Gi
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.memory
+          value: 1Gi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -89,10 +89,15 @@ controllers:
           - name: http
             containerPort: 8080
         resources:
-          # 1.5Gi limit covers Py-ART peak (~1.1Gi) on busy stations.
-          # See PR #104 history for profiling notes.
-          requests: { cpu: 100m, memory: 512Mi }
-          limits:   { memory: 1536Mi }
+          # Py-ART peak is ~1.1Gi on busy stations (PR #104 profiling), but a
+          # long-running matplotlib/Cartopy process accretes headroom pressure
+          # and the old 1536Mi limit OOMKilled (exit 137) roughly every 4h in
+          # production over multi-day runs (issue #125). 3Gi is deliberately
+          # generous to stop the OOMKills; requests raised to 1Gi so the
+          # scheduler reserves a realistic floor rather than the 512Mi that
+          # never reflected steady-state usage.
+          requests: { cpu: 100m, memory: 1Gi }
+          limits:   { memory: 3Gi }
         probes:
           # Gate on this: dras doesn't start until /healthz is 200.
           # ~5s × 30 = 150s budget covers cold Py-ART/matplotlib
@@ -158,6 +163,35 @@ persistence:
         renderer:
           - path: /tmp
             subPath: renderer
+
+  # Writable Cartopy cache for the renderer (issue #125).
+  #
+  # Cartopy resolves Natural Earth shapefiles under ~/.local/share/cartopy
+  # (HOME=/home/renderer). The renderer image bakes and read-only-verifies
+  # that cache under uid 65532 at build time (Dockerfile, issues #107/#108),
+  # so warmed layers already render out of the box. What the baked cache
+  # cannot do is absorb a *cache miss* — a Cartopy/Natural-Earth version bump
+  # that needs a layer not in the pre-warm list, or a future render.py layer
+  # added without updating scripts/cartopy_cache.py. On the read-only baked
+  # dir that miss triggers a download to ~/.local/share/cartopy and 500s with
+  # PermissionError (EACCES) under runAsUser: 65532.
+  #
+  # This emptyDir gives that path a writable overlay so a miss self-heals by
+  # downloading into the pod's cache instead of failing the request. Cache is
+  # per-pod-lifetime; switch type to a PVC if you want it to survive restarts.
+  #
+  # NOTE: mounting here shadows the image's baked cache, so the first render
+  # in a fresh pod re-downloads the Natural Earth layers (needs egress to the
+  # Natural Earth CDN). In an air-gapped cluster set enabled: false and rely
+  # on the baked read-only cache instead.
+  cartopy-cache:
+    enabled: true
+    type: emptyDir
+    sizeLimit: 256Mi
+    advancedMounts:
+      dras:
+        renderer:
+          - path: /home/renderer/.local/share/cartopy
 
 # ── app-template required top-level stubs ────────────────────────────────
 # app-template/common iterates these keys directly; they must be present as


### PR DESCRIPTION
## Summary

Two out-of-box renderer reliability fixes for `mode: advanced` chart defaults, per issue #125. Both are `chart/values.yaml`-only (plus helm-unittest coverage).

## 1. Writable Cartopy cache

Adds a `cartopy-cache` `emptyDir` mounted at `/home/renderer/.local/share/cartopy` on the renderer sidecar — this is the maintainer's option (a) YAML from the issue, the smallest chart change.

**Important interaction worth a maintainer eyeball:** since the issue was filed against chart v2.12.0, the renderer image gained a baked, read-only-verified Cartopy cache (Dockerfile `COPY --from=builder .../cartopy` + `chmod -R a+rX` + a `USER 65532` verification step, issues #107/#108). So warmed layers — including `admin_2_counties_lakes` (the file in the issue's trace) — already render out of the box on the current image. What the baked read-only cache still cannot do is absorb a **cache miss**: a Cartopy/Natural-Earth version bump that needs a layer not in `scripts/cartopy_cache.py`, or a future `render.py` layer added without updating the warm list. That miss triggers a download into `~/.local/share/cartopy` and 500s with `PermissionError` (EACCES) under `runAsUser: 65532`. This writable overlay lets such a miss self-heal.

Trade-off (documented in the values comment): the mount **shadows** the image's baked cache, so the first render in a fresh pod re-downloads the Natural Earth layers and needs egress to the Natural Earth CDN. Air-gapped clusters should set `enabled: false` and rely on the baked read-only cache. If you'd rather keep the bake authoritative and only overlay on miss, the alternative is your option (b) (image-side `CARTOPY_DATA_DIR` to a writable path) — happy to redo it that way; I went with the option (a) YAML you sketched.

Cache is per-pod-lifetime; the comment notes switching `type` to a PVC to persist across restarts.

## 2. Raised renderer memory

Bumps the renderer initContainer from `limits: 1536Mi / requests: 512Mi` to `limits: 3Gi / requests: 1Gi`. The old 1536Mi left ~400Mi over the ~1.1Gi Py-ART peak and OOMKilled (exit 137) roughly every 4h over multi-day runs. 3Gi matches the issue's proposal; requests raised to 1Gi so the scheduler reserves a realistic floor. (You noted willingness to try a tighter 2Gi once Problem 1 lands — easy to adjust.)

## Validation

- `helm template` renders the mount at `/home/renderer/.local/share/cartopy`, the backing `emptyDir` (256Mi), and renderer `limits.memory: 3Gi` / `requests.memory: 1Gi`.
- `helm lint` clean (only the pre-existing `icon is recommended` INFO).
- `helm unittest chart/` green — 25 tests, incl. new advanced-mode assertions for the cartopy-cache mount, its emptyDir volume, and the raised memory.
- **Standard mode** still strips the renderer, its cartopy mount, and the volume with zero dangling references.

## Test categories

Chart/YAML change — validated via helm's own tooling (template + lint + unittest) rather than the Go 7-category suite, which does not apply to a values-only change. New helm-unittest assertions cover the rendered mount, volume, and resource limits (Functional/Frame equivalent); Security/Performance/Retry/Integration are N/A for a static values default.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)