### PR TITLE
fix(renderer): downgrade benign "No MSG31 records" 502 to INFO

### DIFF
--- a/dras/internal/image/image.go
+++ b/dras/internal/image/image.go
@@ -44,6 +44,15 @@ type Image struct {
 	FetchedAt   time.Time
 }
 
+// ErrScanIncomplete is a soft-fail signal from a Source: the upstream radar
+// volume was fetched mid-write, so the scan is not yet renderable (e.g. the
+// renderer decoded the Level II archive and found no MSG31 / message-31
+// reflectivity records yet). This is an accepted "upstream-not-ready" skip,
+// not a true failure — the next poll picks up the completed volume. Callers
+// should log it at INFO and continue rather than treating it as a WARN.
+// Detect with errors.Is(err, image.ErrScanIncomplete). Issue #122.
+var ErrScanIncomplete = errors.New("scan not yet complete")
+
 // Source supplies radar images for stations. Implementations decide where
 // images come from (downloaded GIFs, rendered Level II data, etc).
 type Source interface {

--- a/dras/internal/monitor/monitor.go
+++ b/dras/internal/monitor/monitor.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -196,7 +197,15 @@ func (m *Monitor) fetchRadarImage(ctx context.Context, stationID string, station
 
 	img, err := m.imageService.Fetch(ctx, stationID)
 	if err != nil {
-		stationLogger.Warn(fmt.Sprintf("Failed to fetch radar image: %v", err))
+		// A mid-write upstream volume (no MSG31 records yet) is an accepted
+		// upstream-not-ready skip, not a failure — the next poll picks up the
+		// completed scan. Log it at INFO so it doesn't masquerade as a WARN in
+		// dashboards/alerts. Everything else stays a WARN. Issue #122.
+		if errors.Is(err, image.ErrScanIncomplete) {
+			stationLogger.Info(fmt.Sprintf("Skipping radar image; upstream scan not yet complete: %v", err))
+		} else {
+			stationLogger.Warn(fmt.Sprintf("Failed to fetch radar image: %v", err))
+		}
 		return nil
 	}
 	return img

--- a/dras/internal/monitor/scan_incomplete_log_test.go
+++ b/dras/internal/monitor/scan_incomplete_log_test.go
@@ -1,0 +1,88 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/jacaudi/dras/internal/config"
+	"github.com/jacaudi/dras/internal/image"
+	"github.com/jacaudi/dras/internal/notify"
+	"github.com/jacaudi/dras/internal/radar"
+)
+
+// Integration coverage for issue #122: fetchRadarImage must log the benign
+// "scan not yet complete" (image.ErrScanIncomplete) case at INFO and every
+// other fetch failure at WARN, in both cases returning a nil image so the
+// notification proceeds text-only.
+
+// fakeSource is a minimal image.Source that returns a preconfigured error.
+type fakeSource struct{ err error }
+
+func (f fakeSource) Fetch(_ context.Context, _ string) (*image.Image, error) { return nil, f.err }
+func (f fakeSource) Latest(_ string) (*image.Image, bool)                    { return nil, false }
+
+// recordingHandler captures the level and message of each emitted record.
+type recordingHandler struct{ records *[]slog.Record }
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func newMonitorForLogTest() *Monitor {
+	return New(radar.NewMockDataFetcher(), notify.NewMockNotifier(), nil, &config.Config{})
+}
+
+func TestFetchRadarImage_ScanIncomplete_LogsInfo(t *testing.T) {
+	var records []slog.Record
+	logger := slog.New(recordingHandler{records: &records})
+
+	m := newMonitorForLogTest()
+	// Real production shape: the renderer client wraps the sentinel with
+	// context around it (fmt.Errorf("...: %w", ..., image.ErrScanIncomplete)).
+	m.imageService = fakeSource{err: fmt.Errorf("renderer returned 502: decode_failed (No MSG31 records): %w", image.ErrScanIncomplete)}
+
+	img := m.fetchRadarImage(context.Background(), "KATX", logger)
+	if img != nil {
+		t.Errorf("expected nil image, got %+v", img)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("expected exactly 1 log record, got %d", len(records))
+	}
+	if records[0].Level != slog.LevelInfo {
+		t.Errorf("level = %v, want INFO for benign scan-incomplete skip", records[0].Level)
+	}
+	if !strings.Contains(records[0].Message, "not yet complete") {
+		t.Errorf("message = %q, want to mention 'not yet complete'", records[0].Message)
+	}
+}
+
+func TestFetchRadarImage_GenericError_LogsWarn(t *testing.T) {
+	var records []slog.Record
+	logger := slog.New(recordingHandler{records: &records})
+
+	m := newMonitorForLogTest()
+	m.imageService = fakeSource{err: fmt.Errorf("renderer returned 500: internal (S3 download failed)")}
+
+	img := m.fetchRadarImage(context.Background(), "KATX", logger)
+	if img != nil {
+		t.Errorf("expected nil image, got %+v", img)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("expected exactly 1 log record, got %d", len(records))
+	}
+	if records[0].Level != slog.LevelWarn {
+		t.Errorf("level = %v, want WARN for a genuine fetch failure", records[0].Level)
+	}
+	if !strings.Contains(records[0].Message, "Failed to fetch radar image") {
+		t.Errorf("message = %q, want the WARN failure text", records[0].Message)
+	}
+}

--- a/dras/internal/renderer/client.go
+++ b/dras/internal/renderer/client.go
@@ -95,6 +95,16 @@ func (c *Client) Fetch(ctx context.Context, stationID string) (*image.Image, err
 	if resp.StatusCode != http.StatusOK {
 		var errBody errorBody
 		if jsonErr := json.Unmarshal(body, &errBody); jsonErr == nil && errBody.Error != "" {
+			// A "decode_failed" whose detail names the missing message-31
+			// records is the benign mid-write case (issue #122): the upstream
+			// NEXRAD volume was fetched before it finished writing, so it has
+			// no reflectivity records yet. Tag it with image.ErrScanIncomplete
+			// so the monitor logs an INFO skip instead of a WARN. The detail
+			// text is preserved in the message for forensics.
+			if isScanIncomplete(errBody) {
+				return nil, fmt.Errorf("renderer returned %d: %s (%s): %w",
+					resp.StatusCode, errBody.Error, errBody.Detail, image.ErrScanIncomplete)
+			}
 			return nil, fmt.Errorf("renderer returned %d: %s (%s)",
 				resp.StatusCode, errBody.Error, errBody.Detail)
 		}
@@ -130,6 +140,18 @@ func (c *Client) Fetch(ctx context.Context, stationID string) (*image.Image, err
 		Filename:    filename,
 		FetchedAt:   scanTime,
 	}, nil
+}
+
+// isScanIncomplete reports whether a renderer error response is the benign
+// "upstream volume fetched mid-write" case: a decode_failed whose detail names
+// the missing message-31 records. Py-ART raises this as a ValueError with the
+// message "No MSG31 records found, cannot read file", which the renderer
+// surfaces verbatim in errBody.Detail. Match is case-insensitive on the stable
+// substring so a wording tweak or capitalization change upstream doesn't turn
+// the skip back into a WARN. Issue #122.
+func isScanIncomplete(b errorBody) bool {
+	return b.Error == "decode_failed" &&
+		strings.Contains(strings.ToLower(b.Detail), "no msg31 records")
 }
 
 // Latest always returns no cached image. The renderer is the source of truth;

--- a/dras/internal/renderer/scan_incomplete_test.go
+++ b/dras/internal/renderer/scan_incomplete_test.go
@@ -1,0 +1,191 @@
+package renderer
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jacaudi/dras/internal/httpretry"
+	"github.com/jacaudi/dras/internal/image"
+)
+
+// Tests for the benign "scan not yet complete" (No MSG31 records) skip
+// classification (issue #122). Covers the 7 categories; the monitor-side
+// INFO-vs-WARN log integration lives in the monitor package.
+
+// decodeFailedBody is the wire shape the renderer emits for a mid-write
+// upstream volume: HTTP 502 with error=decode_failed and the Py-ART
+// ValueError text in detail.
+const noMSG31Detail = "No MSG31 records found, cannot read file"
+
+func writeErr(w http.ResponseWriter, status int, code, detail string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{Error: code, Detail: detail})
+}
+
+// --- Unit -----------------------------------------------------------------
+func TestIsScanIncomplete_Unit(t *testing.T) {
+	tests := []struct {
+		name string
+		body errorBody
+		want bool
+	}{
+		{name: "benign_no_msg31", body: errorBody{Error: "decode_failed", Detail: noMSG31Detail}, want: true},
+		{name: "case_insensitive", body: errorBody{Error: "decode_failed", Detail: "no msg31 records here"}, want: true},
+		{name: "decode_failed_other_detail", body: errorBody{Error: "decode_failed", Detail: "truncated gzip member"}, want: false},
+		{name: "other_code_same_detail", body: errorBody{Error: "internal", Detail: noMSG31Detail}, want: false},
+		{name: "no_recent_scan", body: errorBody{Error: "no_recent_scan", Detail: "none today"}, want: false},
+		{name: "empty", body: errorBody{}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isScanIncomplete(tt.body); got != tt.want {
+				t.Errorf("isScanIncomplete(%+v) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Functional -----------------------------------------------------------
+func TestFetch_ScanIncomplete_WrapsSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeErr(w, http.StatusBadGateway, "decode_failed", noMSG31Detail)
+	}))
+	defer srv.Close()
+
+	// Non-retrying client: this asserts classification, not retry behavior.
+	c := New(Config{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: 5 * time.Second}})
+	_, err := c.Fetch(t.Context(), "KATX")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, image.ErrScanIncomplete) {
+		t.Errorf("err = %v, want errors.Is(err, image.ErrScanIncomplete)", err)
+	}
+	// Detail is preserved for forensics.
+	if !strings.Contains(err.Error(), noMSG31Detail) {
+		t.Errorf("err = %v, want to preserve detail %q", err, noMSG31Detail)
+	}
+}
+
+func TestFetch_DecodeFailedOther_IsHardError(t *testing.T) {
+	// A decode_failed that is NOT the mid-write case must stay a hard error
+	// (not downgraded), so genuine corruption is still visible as a WARN.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeErr(w, http.StatusBadGateway, "decode_failed", "truncated gzip member")
+	}))
+	defer srv.Close()
+
+	c := New(Config{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: 5 * time.Second}})
+	_, err := c.Fetch(t.Context(), "KATX")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, image.ErrScanIncomplete) {
+		t.Errorf("err = %v, must NOT be classified as scan-incomplete", err)
+	}
+	if !strings.Contains(err.Error(), "decode_failed") {
+		t.Errorf("err = %v, want to contain 'decode_failed'", err)
+	}
+}
+
+// --- Security -------------------------------------------------------------
+// Adversarial/oversized detail strings must neither panic nor be
+// misclassified. Only the exact stable substring under decode_failed trips
+// the skip; a hostile detail cannot smuggle a real failure into the silent
+// INFO path, and a real failure cannot be masked.
+func TestFetch_ScanIncomplete_Security_NoMisclassify(t *testing.T) {
+	cases := []struct {
+		code, detail string
+		wantSkip     bool
+	}{
+		{"decode_failed", strings.Repeat("A", 1<<16), false},            // oversized, unrelated
+		{"decode_failed", "MSG31 records missing", false},               // near-miss wording, not the phrase
+		{"decode_failed", "prefix no msg31 records suffix", true},       // substring embedded, still benign
+		{"internal", "no msg31 records\n'; DROP TABLE scans;--", false}, // injection-ish + wrong code
+		{"decode_failed", "no msg31 records\x00 truncated", true},       // NUL byte, still matches phrase
+	}
+	for _, tc := range cases {
+		got := isScanIncomplete(errorBody{Error: tc.code, Detail: tc.detail})
+		if got != tc.wantSkip {
+			t.Errorf("isScanIncomplete(code=%q detail=%q) = %v, want %v", tc.code, truncate(tc.detail), got, tc.wantSkip)
+		}
+	}
+}
+
+func truncate(s string) string {
+	if len(s) > 40 {
+		return s[:40] + "..."
+	}
+	return s
+}
+
+// --- Retry ----------------------------------------------------------------
+// The renderer 502 is retried with backoff by the default transport (a
+// mid-write volume often completes between attempts). This asserts the
+// external call is retried AND the sentinel survives to the final error, so
+// the INFO classification still applies after retries are exhausted.
+func TestFetch_ScanIncomplete_Retry(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		writeErr(w, http.StatusBadGateway, "decode_failed", noMSG31Detail)
+	}))
+	defer srv.Close()
+
+	rt := &httpretry.Transport{
+		MaxAttempts:    3,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     5 * time.Millisecond,
+	}
+	c := New(Config{BaseURL: srv.URL, HTTPClient: &http.Client{Transport: rt}})
+
+	_, err := c.Fetch(t.Context(), "KATX")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Errorf("server hits = %d, want 3 (all attempts retried with backoff)", got)
+	}
+	if !errors.Is(err, image.ErrScanIncomplete) {
+		t.Errorf("err after retries = %v, want errors.Is(err, image.ErrScanIncomplete)", err)
+	}
+}
+
+// --- Performance ----------------------------------------------------------
+func BenchmarkIsScanIncomplete(b *testing.B) {
+	body := errorBody{Error: "decode_failed", Detail: noMSG31Detail}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = isScanIncomplete(body)
+	}
+}
+
+// --- Frame ----------------------------------------------------------------
+// Builds & runs end-to-end: real HTTP round-trip through the client against a
+// server emitting the exact renderer 502 body, asserting the wrapped sentinel
+// reaches the caller.
+func TestFetch_ScanIncomplete_Frame_EndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/render/KATX" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeErr(w, http.StatusBadGateway, "decode_failed", noMSG31Detail)
+	}))
+	defer srv.Close()
+
+	c := New(Config{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: 5 * time.Second}})
+	img, err := c.Fetch(t.Context(), "KATX")
+	if img != nil {
+		t.Errorf("expected nil image on scan-incomplete, got %+v", img)
+	}
+	if !errors.Is(err, image.ErrScanIncomplete) {
+		t.Fatalf("Frame: err = %v, want errors.Is(err, image.ErrScanIncomplete)", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **option 3** of issue #122. When the renderer fetches a NEXRAD Level II volume that upstream was still mid-write, Py-ART decodes it, finds no message-31 (reflectivity) records, and the renderer returns `502 decode_failed` with detail `No MSG31 records found, cannot read file`. That's an accepted "upstream-not-ready" timing artifact — the next poll picks up the completed scan — but dras logged it at **WARN**, so a routine condition looked like a real failure in dashboards/alerts (the issue reports ~11 such WARNs over a 44h window).

This downgrades *only that specific benign case* to **INFO**, leaving every other failure at WARN.

## Changes

- **`internal/image/image.go`** — new `ErrScanIncomplete` sentinel, documented as part of the `Source` contract (a Source may report a benign "not yet renderable" skip).
- **`internal/renderer/client.go`** — `Fetch` tags the `decode_failed` + "No MSG31 records" 502 by wrapping `image.ErrScanIncomplete` (case-insensitive match on the stable substring; the detail text is preserved in the error for forensics). A `decode_failed` from any *other* cause (truncation, corruption) stays a hard error, so genuine failures remain visible as WARN.
- **`internal/monitor/monitor.go`** — `fetchRadarImage` logs `image.ErrScanIncomplete` at INFO and everything else at WARN; both paths still return a nil image so the notification proceeds text-only.

**Design note:** the sentinel lives in the `image` package rather than `renderer` so the monitor can detect it via `errors.Is` without taking a new dependency on the renderer package (monitor already imports `image`, not `renderer`).

**Retry behavior is unchanged** — the 502 is still retried with backoff by `httpretry` (a mid-write volume often completes between attempts); only the final log level changes.

## Test categories

- **Unit** — `TestIsScanIncomplete_Unit`: truth table (benign, case-insensitive, other decode_failed detail, wrong error code, empty).
- **Functional** — `Fetch` wraps the sentinel for the benign case and preserves detail; a different `decode_failed` detail stays a hard error (`errors.Is` false).
- **Performance** — `BenchmarkIsScanIncomplete`.
- **Integration** — monitor `fetchRadarImage` logs INFO for the sentinel and WARN otherwise, verified through a recording `slog.Handler` (asserts level + message + nil image).
- **Security** — adversarial/oversized/NUL/injection-ish detail strings neither panic nor misclassify; a real failure can't be smuggled into the silent INFO path, and a real failure can't be masked.
- **Retry** — the default transport retries the 502 with backoff and the sentinel survives to the final error, so the INFO classification still applies after retries exhaust.
- **Frame** — end-to-end HTTP round-trip through the client against a server emitting the exact renderer 502 body.

`go build ./... && go vet ./... && go test ./...` all green (module root is `dras/`); also `go test -race` clean on the touched packages; `gofmt` clean.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)